### PR TITLE
feat: add receipt editing, deletion and filtering

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -4,22 +4,20 @@ import { TrendingUp, Euro, FileText } from "lucide-react";
 
 interface DashboardProps {
   receipts: ReceiptType[];
+  selectedYear: string;
 }
 
-const Dashboard = ({ receipts }: DashboardProps) => {
-  const currentYear = new Date().getFullYear().toString();
-  const currentYearReceipts = receipts.filter(receipt => 
-    receipt.date.startsWith(currentYear)
-  );
-  
-  const totalAmount = currentYearReceipts.reduce((sum, receipt) => sum + receipt.amount, 0);
+const Dashboard = ({ receipts, selectedYear }: DashboardProps) => {
+  const displayYear = selectedYear === 'all' ? 'Toutes' : selectedYear;
+
+  const totalAmount = receipts.reduce((sum, receipt) => sum + receipt.amount, 0);
   const taxReduction = Math.round(totalAmount * 0.66);
 
   return (
     <div className="space-y-6">
       <div className="text-center py-6">
         <h2 className="text-3xl font-bold text-foreground mb-2">
-          Année {currentYear}
+          {displayYear === 'Toutes' ? 'Toutes années' : `Année ${displayYear}`}
         </h2>
         <p className="text-muted-foreground">
           Votre synthèse fiscale en temps réel
@@ -29,16 +27,16 @@ const Dashboard = ({ receipts }: DashboardProps) => {
       <div className="grid gap-4 md:grid-cols-3">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Dons effectués</CardTitle>
-            <FileText className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{currentYearReceipts.length}</div>
-            <p className="text-xs text-muted-foreground">
-              reçu{currentYearReceipts.length > 1 ? 's' : ''} cette année
-            </p>
-          </CardContent>
-        </Card>
+              <CardTitle className="text-sm font-medium">Dons effectués</CardTitle>
+              <FileText className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{receipts.length}</div>
+              <p className="text-xs text-muted-foreground">
+                reçu{receipts.length > 1 ? 's' : ''} {displayYear === 'Toutes' ? 'au total' : 'cette année'}
+              </p>
+            </CardContent>
+          </Card>
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">

--- a/src/components/ReceiptsList.tsx
+++ b/src/components/ReceiptsList.tsx
@@ -1,13 +1,16 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Receipt as ReceiptType } from "@/types/Receipt";
-import { Calendar, Building2, Euro } from "lucide-react";
+import { Calendar, Building2, Euro, Trash, Pencil } from "lucide-react";
 
 interface ReceiptsListProps {
   receipts: ReceiptType[];
+  onDeleteReceipt: (id: string) => void;
+  onEditReceipt: (receipt: ReceiptType) => void;
 }
 
-const ReceiptsList = ({ receipts }: ReceiptsListProps) => {
+const ReceiptsList = ({ receipts, onDeleteReceipt, onEditReceipt }: ReceiptsListProps) => {
   const sortedReceipts = [...receipts].sort((a, b) => 
     new Date(b.date).getTime() - new Date(a.date).getTime()
   );
@@ -51,14 +54,32 @@ const ReceiptsList = ({ receipts }: ReceiptsListProps) => {
                   <Building2 className="h-4 w-4 text-muted-foreground" />
                   <span className="font-medium">{receipt.organism}</span>
                 </div>
-                
+
                 <div className="flex items-center gap-2 text-sm text-muted-foreground">
                   <Calendar className="h-3 w-3" />
                   <span>{formatDate(receipt.date)}</span>
                 </div>
               </div>
-              
+
               <div className="text-right space-y-2">
+                <div className="flex justify-end gap-2">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => onEditReceipt(receipt)}
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => {
+                      if (confirm("Supprimer ce reçu ?")) onDeleteReceipt(receipt.id);
+                    }}
+                  >
+                    <Trash className="h-4 w-4 text-destructive" />
+                  </Button>
+                </div>
                 <div className="flex items-center gap-1">
                   <Euro className="h-4 w-4 text-muted-foreground" />
                   <span className="font-semibold text-lg">{receipt.amount.toLocaleString('fr-FR')} €</span>


### PR DESCRIPTION
## Summary
- allow editing receipts via pre-filled form and update flow
- add receipt deletion with confirmation prompts
- support year and text filtering with updated dashboard metrics

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af573d2a3483218e63c0d6ab3262ad