### PR TITLE
feat: manage receipt photos with capture, view, and delete options

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -69,6 +69,10 @@ const Index = () => {
     setReceipts(prev => prev.filter(r => r.id !== id));
   };
 
+  const handleUpdateReceiptPhoto = (id: string, photo: string | null) => {
+    setReceipts(prev => prev.map(r => (r.id === id ? { ...r, photo: photo || undefined } : r)));
+  };
+
   const years = Array.from(new Set(receipts.map(r => r.date.slice(0, 4)))).sort().reverse();
 
   const filteredReceipts = receipts.filter((r) => {
@@ -121,6 +125,7 @@ const Index = () => {
                 receipts={filteredReceipts}
                 onDeleteReceipt={handleDeleteReceipt}
                 onEditReceipt={(receipt) => setEditingReceipt(receipt)}
+                onUpdatePhoto={handleUpdateReceiptPhoto}
               />
             </div>
           </div>

--- a/src/types/Receipt.ts
+++ b/src/types/Receipt.ts
@@ -3,6 +3,7 @@ export interface Receipt {
   date: string; // Format YYYY-MM-DD
   organism: string;
   amount: number;
+  photo?: string | null;
   createdAt: string;
 }
 


### PR DESCRIPTION
## Summary
- add optional photo field when creating or editing receipts
- allow viewing, replacing, and deleting receipt photos

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0a3cbf88083218ee99f26324fdf1f