### PR TITLE
feat: manage receipt photos

### DIFF
--- a/src/components/AddReceiptForm.tsx
+++ b/src/components/AddReceiptForm.tsx
@@ -83,6 +83,12 @@ const AddReceiptForm = ({ onAddReceipt, initialData, onUpdateReceipt, onCancelEd
   const handlePhotoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+
+    if (photo && !confirm("Remplacer la photo existante ?")) {
+      e.target.value = "";
+      return;
+    }
+
     const reader = new FileReader();
     reader.onloadend = () => {
       setPhoto(reader.result as string);

--- a/src/components/ReceiptsList.tsx
+++ b/src/components/ReceiptsList.tsx
@@ -42,7 +42,7 @@ const ReceiptsList = ({ receipts, onDeleteReceipt, onEditReceipt, onUpdatePhoto 
   };
 
   const handleViewPhoto = (photo?: string | null) => {
-    if (photo) window.open(photo, '_blank');
+    if (photo) window.open(photo, '_blank', 'noopener,noreferrer');
   };
 
   const handleDeletePhoto = (id: string) => {


### PR DESCRIPTION
## Summary
- prompt before replacing existing receipt photo
- open receipt images in a safe new tab

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b14ac9dcc88321906ea3f43e2013e8