### PR TITLE
feat: add services page for tax credits

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import Services from "./pages/Services";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -16,6 +17,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/services" element={<Services />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/AddServiceForm.tsx
+++ b/src/components/AddServiceForm.tsx
@@ -1,0 +1,334 @@
+import { useState, useEffect, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { ServiceExpense } from "@/types/ServiceExpense";
+import { Plus, Camera, ImageOff } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+
+interface AddServiceFormProps {
+  onAdd: (expense: ServiceExpense) => void;
+  initialData?: ServiceExpense;
+  onUpdate?: (expense: ServiceExpense) => void;
+  onCancelEdit?: () => void;
+}
+
+const AddServiceForm = ({ onAdd, initialData, onUpdate, onCancelEdit }: AddServiceFormProps) => {
+  const [isFormOpen, setIsFormOpen] = useState(!!initialData);
+  const [formData, setFormData] = useState({
+    date: initialData?.date || "",
+    category: initialData?.category || "home",
+    nature: initialData?.nature || "",
+    provider: initialData?.provider || "",
+    amount: initialData?.amount ? initialData.amount.toString() : "",
+    aids: initialData?.aids ? initialData.aids.toString() : "0",
+    childName: initialData?.childName || "",
+    childBirthDate: initialData?.childBirthDate || "",
+  });
+  const [photo, setPhoto] = useState<string | null>(initialData?.photo || null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (initialData) {
+      setIsFormOpen(true);
+      setFormData({
+        date: initialData.date,
+        category: initialData.category,
+        nature: initialData.nature,
+        provider: initialData.provider,
+        amount: initialData.amount.toString(),
+        aids: initialData.aids.toString(),
+        childName: initialData.childName || "",
+        childBirthDate: initialData.childBirthDate || "",
+      });
+      setPhoto(initialData.photo || null);
+    }
+  }, [initialData]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!formData.date || !formData.nature || !formData.provider || !formData.amount) {
+      toast({
+        title: "Champs manquants",
+        description: "Veuillez remplir tous les champs obligatoires.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (formData.category === "childcare" && (!formData.childName || !formData.childBirthDate)) {
+      toast({
+        title: "Informations enfant manquantes",
+        description: "Nom et date de naissance de l'enfant requis pour la garde d'enfants.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const newExpense: ServiceExpense = {
+      id: initialData?.id || Date.now().toString(),
+      date: formData.date,
+      category: formData.category as "home" | "childcare",
+      nature: formData.nature.trim(),
+      provider: formData.provider.trim(),
+      amount: parseFloat(formData.amount),
+      aids: parseFloat(formData.aids || "0"),
+      childName: formData.category === "childcare" ? formData.childName.trim() : undefined,
+      childBirthDate: formData.category === "childcare" ? formData.childBirthDate : undefined,
+      photo: photo || undefined,
+      createdAt: initialData?.createdAt || new Date().toISOString(),
+    };
+
+    if (initialData && onUpdate) {
+      onUpdate(newExpense);
+      toast({
+        title: "Dépense mise à jour !",
+        description: `${newExpense.nature} enregistré pour ${newExpense.provider}.`,
+      });
+    } else {
+      onAdd(newExpense);
+      toast({
+        title: "Dépense ajoutée !",
+        description: `${newExpense.nature} enregistré pour ${newExpense.provider}.`,
+      });
+    }
+
+    setFormData({
+      date: "",
+      category: "home",
+      nature: "",
+      provider: "",
+      amount: "",
+      aids: "0",
+      childName: "",
+      childBirthDate: "",
+    });
+    setPhoto(null);
+    setIsFormOpen(false);
+  };
+
+  const handleInputChange = (field: string, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handlePhotoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (photo && !confirm("Remplacer la photo existante ?")) {
+      e.target.value = "";
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setPhoto(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  if (!isFormOpen) {
+    return (
+      <Card className="border-dashed border-2 border-muted-foreground/30 hover:border-primary/50 transition-colors">
+        <CardContent className="p-8">
+          <div className="text-center space-y-4">
+            <div className="bg-secondary rounded-full p-4 w-16 h-16 mx-auto flex items-center justify-center">
+              <Camera className="h-8 w-8 text-muted-foreground" />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-2">Ajouter une dépense</h3>
+              <p className="text-muted-foreground text-sm mb-4">
+                Ajoutez une nouvelle dépense de services à la personne
+              </p>
+              <Button onClick={() => setIsFormOpen(true)} className="gap-2">
+                <Plus className="h-4 w-4" />
+                Nouvelle dépense
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Camera className="h-5 w-5" />
+          {initialData ? "Modifier la dépense" : "Nouvelle dépense"}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-2">
+            <Label htmlFor="date">Date *</Label>
+            <Input
+              id="date"
+              type="date"
+              value={formData.date}
+              onChange={(e) => handleInputChange("date", e.target.value)}
+              className="w-full"
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>Catégorie *</Label>
+            <Select value={formData.category} onValueChange={(v) => handleInputChange("category", v)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Catégorie" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="home">Service à domicile</SelectItem>
+                <SelectItem value="childcare">Garde d'enfants hors domicile</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="nature">Nature de la dépense *</Label>
+            <Input
+              id="nature"
+              type="text"
+              placeholder="ex: Ménage, Jardinage"
+              value={formData.nature}
+              onChange={(e) => handleInputChange("nature", e.target.value)}
+              className="w-full"
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="provider">Organisme / prestataire *</Label>
+            <Input
+              id="provider"
+              type="text"
+              placeholder="Nom du prestataire"
+              value={formData.provider}
+              onChange={(e) => handleInputChange("provider", e.target.value)}
+              className="w-full"
+              required
+            />
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="amount">Montant (€) *</Label>
+              <Input
+                id="amount"
+                type="number"
+                step="0.01"
+                min="0"
+                value={formData.amount}
+                onChange={(e) => handleInputChange("amount", e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="aids">Aides perçues (€)</Label>
+              <Input
+                id="aids"
+                type="number"
+                step="0.01"
+                min="0"
+                value={formData.aids}
+                onChange={(e) => handleInputChange("aids", e.target.value)}
+              />
+            </div>
+          </div>
+
+          {formData.category === "childcare" && (
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="childName">Nom de l'enfant *</Label>
+                <Input
+                  id="childName"
+                  type="text"
+                  value={formData.childName}
+                  onChange={(e) => handleInputChange("childName", e.target.value)}
+                  required={formData.category === "childcare"}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="childBirthDate">Date de naissance *</Label>
+                <Input
+                  id="childBirthDate"
+                  type="date"
+                  value={formData.childBirthDate}
+                  onChange={(e) => handleInputChange("childBirthDate", e.target.value)}
+                  required={formData.category === "childcare"}
+                />
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label>Justificatif</Label>
+            <div className="flex items-center gap-2">
+              {photo && (
+                <img src={photo} alt="Justificatif" className="h-20 w-20 object-cover rounded" />
+              )}
+              <Button
+                type="button"
+                variant="outline"
+                className="gap-2"
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <Camera className="h-4 w-4" />
+                {photo ? "Remplacer" : "Ajouter"}
+              </Button>
+              {photo && (
+                <Button type="button" variant="ghost" onClick={() => setPhoto(null)}>
+                  <ImageOff className="h-4 w-4" />
+                </Button>
+              )}
+            </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              capture="environment"
+              className="hidden"
+              onChange={handlePhotoChange}
+            />
+          </div>
+
+          <div className="flex gap-3 pt-4">
+            <Button type="submit" className="flex-1">
+              {initialData ? "Mettre à jour" : "Enregistrer"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setIsFormOpen(false);
+                setFormData({
+                  date: "",
+                  category: "home",
+                  nature: "",
+                  provider: "",
+                  amount: "",
+                  aids: "0",
+                  childName: "",
+                  childBirthDate: "",
+                });
+                setPhoto(null);
+                if (initialData && onCancelEdit) onCancelEdit();
+              }}
+              className="flex-1"
+            >
+              Annuler
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default AddServiceForm;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,15 +1,23 @@
 import logo from "@/assets/logo_pimpo.png";
+import { Link, useLocation } from "react-router-dom";
 
 const Header = () => {
+  const location = useLocation();
   return (
     <header className="bg-card border-b border-border">
       <div className="container mx-auto px-4 py-6">
-        <div className="flex items-center gap-3">
-          <img src={logo} alt="Logo Pimpo" className="h-12 w-12" />
-          <div>
-            <h1 className="text-2xl font-bold text-foreground">Pimpo</h1>
-            <p className="text-sm text-muted-foreground">Pour pimper votre déclaration d'impôts</p>
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <img src={logo} alt="Logo Pimpo" className="h-12 w-12" />
+            <div>
+              <h1 className="text-2xl font-bold text-foreground">Pimpo</h1>
+              <p className="text-sm text-muted-foreground">Pour pimper votre déclaration d'impôts</p>
+            </div>
           </div>
+          <nav className="flex gap-4">
+            <Link to="/" className={`text-sm font-medium hover:underline ${location.pathname === '/' ? 'text-primary' : 'text-foreground'}`}>Dons 66%</Link>
+            <Link to="/services" className={`text-sm font-medium hover:underline ${location.pathname === '/services' ? 'text-primary' : 'text-foreground'}`}>Services à la personne</Link>
+          </nav>
         </div>
       </div>
     </header>

--- a/src/components/ServicesDashboard.tsx
+++ b/src/components/ServicesDashboard.tsx
@@ -1,0 +1,92 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ServiceExpense } from "@/types/ServiceExpense";
+import { FileText, Euro, TrendingUp, Baby } from "lucide-react";
+
+interface ServicesDashboardProps {
+  expenses: ServiceExpense[];
+  selectedYear: string;
+}
+
+const ServicesDashboard = ({ expenses, selectedYear }: ServicesDashboardProps) => {
+  const displayYear = selectedYear === 'all' ? 'Toutes' : selectedYear;
+  const net = (e: ServiceExpense) => e.amount - e.aids;
+
+  const homeTotal = expenses
+    .filter(e => e.category === 'home')
+    .reduce((sum, e) => sum + net(e), 0);
+  const homeCapped = Math.min(homeTotal, 12000);
+
+  const childMap: Record<string, number> = {};
+  expenses
+    .filter(e => e.category === 'childcare')
+    .forEach(e => {
+      const key = `${e.childName || ''}|${e.childBirthDate || ''}`;
+      childMap[key] = (childMap[key] || 0) + net(e);
+    });
+  const childTotal = Object.values(childMap).reduce((s, amt) => s + amt, 0);
+  const childTotalCapped = Object.values(childMap).reduce((s, amt) => s + Math.min(amt, 3500), 0);
+
+  const credit = Math.round(homeCapped * 0.5 + childTotalCapped * 0.5);
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center py-6">
+        <h2 className="text-3xl font-bold text-foreground mb-2">
+          {displayYear === 'Toutes' ? 'Toutes années' : `Année ${displayYear}`}
+        </h2>
+        <p className="text-muted-foreground">Synthèse des services à la personne</p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Dépenses enregistrées</CardTitle>
+            <FileText className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{expenses.length}</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Services à domicile (7DB)</CardTitle>
+            <Euro className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{homeTotal.toLocaleString('fr-FR')} €</div>
+            <p className="text-xs text-muted-foreground">
+              plafond 12 000 €
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Garde d'enfants (7DF)</CardTitle>
+            <Baby className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{childTotal.toLocaleString('fr-FR')} €</div>
+            <p className="text-xs text-muted-foreground">
+              plafond 3 500 € / enfant
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-success-light border-success/20">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-success">Crédit d'impôt estimé</CardTitle>
+            <TrendingUp className="h-4 w-4 text-success" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-success">{credit.toLocaleString('fr-FR')} €</div>
+            <p className="text-xs text-success/80">50 % des dépenses éligibles</p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default ServicesDashboard;

--- a/src/components/ServicesList.tsx
+++ b/src/components/ServicesList.tsx
@@ -1,0 +1,165 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ServiceExpense } from "@/types/ServiceExpense";
+import { Calendar, Building2, Euro, Trash, Pencil, Eye, Camera, ImageOff } from "lucide-react";
+import { useRef } from "react";
+
+interface ServicesListProps {
+  expenses: ServiceExpense[];
+  onDelete: (id: string) => void;
+  onEdit: (expense: ServiceExpense) => void;
+  onUpdatePhoto: (id: string, photo: string | null) => void;
+}
+
+const ServicesList = ({ expenses, onDelete, onEdit, onUpdatePhoto }: ServicesListProps) => {
+  const sorted = [...expenses].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  const fileInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('fr-FR', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric'
+    });
+  };
+
+  const handlePhotoChange = (id: string, e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const existing = expenses.find(r => r.id === id)?.photo;
+    if (existing && !confirm("Remplacer la photo existante ?")) {
+      e.target.value = "";
+      return;
+    }
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      onUpdatePhoto(id, reader.result as string);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleViewPhoto = (photo?: string | null) => {
+    if (photo) window.open(photo, '_blank', 'noopener,noreferrer');
+  };
+
+  const handleDeletePhoto = (id: string) => {
+    const existing = expenses.find(r => r.id === id)?.photo;
+    if (existing && confirm("Supprimer la photo ?")) {
+      onUpdatePhoto(id, null);
+    }
+  };
+
+  if (expenses.length === 0) {
+    return (
+      <Card>
+        <CardContent className="p-8 text-center">
+          <div className="text-muted-foreground">
+            <Calendar className="h-12 w-12 mx-auto mb-4 opacity-50" />
+            <h3 className="text-lg font-medium mb-2">Aucune dépense enregistrée</h3>
+            <p className="text-sm">Ajoutez vos premières dépenses de services à la personne.</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Dépenses ({expenses.length})</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {sorted.map((exp) => {
+          const net = exp.amount - exp.aids;
+          return (
+            <div
+              key={exp.id}
+              className="border border-border rounded-lg p-4 space-y-3 hover:bg-muted/30 transition-colors"
+            >
+              <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4">
+                <div className="space-y-2 flex-1">
+                  <div className="flex items-center gap-2">
+                    <Building2 className="h-4 w-4 text-muted-foreground" />
+                    <span className="font-medium">{exp.provider}</span>
+                  </div>
+                  <div className="text-sm text-muted-foreground">{exp.nature}</div>
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Calendar className="h-3 w-3" />
+                    <span>{formatDate(exp.date)}</span>
+                  </div>
+                  {exp.category === 'childcare' && exp.childName && (
+                    <div className="text-sm text-muted-foreground">
+                      Enfant : {exp.childName}
+                    </div>
+                  )}
+                </div>
+
+                <div className="space-y-2 sm:text-right">
+                  <input
+                    type="file"
+                    accept="image/*"
+                    capture="environment"
+                    className="hidden"
+                    ref={(el) => (fileInputRefs.current[exp.id] = el)}
+                    onChange={(e) => handlePhotoChange(exp.id, e)}
+                  />
+                  <div className="grid grid-cols-3 gap-2 sm:flex sm:justify-end">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleViewPhoto(exp.photo)}
+                      disabled={!exp.photo}
+                    >
+                      <Eye className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => fileInputRefs.current[exp.id]?.click()}
+                    >
+                      <Camera className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleDeletePhoto(exp.id)}
+                      disabled={!exp.photo}
+                    >
+                      <ImageOff className="h-4 w-4 text-destructive" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => onEdit(exp)}
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => {
+                        if (confirm("Supprimer cette dépense ?")) onDelete(exp.id);
+                      }}
+                    >
+                      <Trash className="h-4 w-4 text-destructive" />
+                    </Button>
+                  </div>
+                  <div className="flex items-center gap-1 sm:justify-end">
+                    <Euro className="h-4 w-4 text-muted-foreground" />
+                    <span className="font-semibold text-lg">{net.toLocaleString('fr-FR')} €</span>
+                  </div>
+                  <Badge variant="secondary" className="text-xs">
+                    {exp.aids > 0 ? `Aides déduites: ${exp.aids.toLocaleString('fr-FR')} €` : 'Sans aide'}
+                  </Badge>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ServicesList;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -131,6 +131,7 @@ const Index = () => {
       </style></head><body>
         <h1>Reçus fiscaux ${title}</h1>
         <p><strong>Montant total des dons :</strong> ${totalAmount.toLocaleString('fr-FR')} €</p>
+        <p>Le montant total des dons de l'année est à saisir dans la case 7UF de la déclaration d'impôts.</p>
         <p><strong>Réduction fiscale (66%) :</strong> ${taxReduction.toLocaleString('fr-FR')} €</p>
         <p>Document justificatif à présenter à l'administration fiscale en cas de contrôle.</p>
         <table><thead><tr><th>Date</th><th>Organisme</th><th>Montant</th></tr></thead><tbody>${rows}</tbody></table>

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -1,0 +1,173 @@
+import { useState, useEffect } from "react";
+import { ServiceExpense } from "@/types/ServiceExpense";
+import Header from "@/components/Header";
+import ServicesDashboard from "@/components/ServicesDashboard";
+import AddServiceForm from "@/components/AddServiceForm";
+import ServicesList from "@/components/ServicesList";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+
+const Services = () => {
+  const [expenses, setExpenses] = useState<ServiceExpense[]>([]);
+  const [editing, setEditing] = useState<ServiceExpense | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedYear, setSelectedYear] = useState("all");
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const stored = localStorage.getItem('pimpo-services');
+    if (stored) {
+      try {
+        setExpenses(JSON.parse(stored));
+      } catch (e) {
+        console.error('Error loading services from localStorage:', e);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('pimpo-services', JSON.stringify(expenses));
+  }, [expenses]);
+
+  const handleAdd = (exp: ServiceExpense) => setExpenses(prev => [...prev, exp]);
+  const handleUpdate = (exp: ServiceExpense) => {
+    setExpenses(prev => prev.map(e => e.id === exp.id ? exp : e));
+    setEditing(null);
+  };
+  const handleDelete = (id: string) => setExpenses(prev => prev.filter(e => e.id !== id));
+  const handleUpdatePhoto = (id: string, photo: string | null) => {
+    setExpenses(prev => prev.map(e => e.id === id ? { ...e, photo: photo || undefined } : e));
+  };
+
+  const years = Array.from(new Set(expenses.map(r => r.date.slice(0,4)))).sort().reverse();
+
+  const filtered = expenses.filter((e) => {
+    const matchesYear = selectedYear === "all" || e.date.startsWith(selectedYear);
+    const text = `${e.provider} ${e.nature}`.toLowerCase();
+    const matchesSearch = text.includes(searchTerm.toLowerCase());
+    return matchesYear && matchesSearch;
+  });
+
+  const handleDownloadPDF = () => {
+    if (filtered.length === 0) {
+      toast({
+        title: "Aucune dépense",
+        description: "Aucune dépense trouvée pour l'année sélectionnée.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const title = selectedYear === "all" ? "Toutes années" : `Année ${selectedYear}`;
+    const net = (e: ServiceExpense) => e.amount - e.aids;
+    const homeTotal = filtered.filter(e => e.category === 'home').reduce((s,e)=>s+net(e),0);
+    const homeCapped = Math.min(homeTotal, 12000);
+    const childMap: Record<string, {name:string; birth:string; amount:number}> = {};
+    filtered.filter(e=>e.category==='childcare').forEach(e=>{
+      const key = `${e.childName||''}|${e.childBirthDate||''}`;
+      const entry = childMap[key] || {name: e.childName||'', birth: e.childBirthDate||'', amount:0};
+      entry.amount += net(e);
+      childMap[key]=entry;
+    });
+    const childTotal = Object.values(childMap).reduce((s,d)=>s+d.amount,0);
+    const childTotalCapped = Object.values(childMap).reduce((s,d)=>s+Math.min(d.amount,3500),0);
+    const credit = Math.round(homeCapped*0.5 + childTotalCapped*0.5);
+
+    const childLines = Object.values(childMap)
+      .map(c => `<p>${c.name} (${new Date(c.birth).toLocaleDateString('fr-FR')}) : ${c.amount.toLocaleString('fr-FR')} €</p>`)
+      .join("");
+
+    const rows = filtered.map(e => {
+      const netAmount = net(e);
+      return `<tr><td>${new Date(e.date).toLocaleDateString('fr-FR')}</td><td>${e.nature}</td><td>${e.provider}</td><td>${e.amount.toLocaleString('fr-FR')} €</td><td>${e.aids.toLocaleString('fr-FR')} €</td><td>${netAmount.toLocaleString('fr-FR')} €</td></tr>`;
+    }).join("");
+
+    const photosHtml = filtered
+      .filter(e => e.photo)
+      .map((e,i)=>`<div class="receipt-photo"><h3>Justificatif ${i+1} - ${e.provider} (${new Date(e.date).toLocaleDateString('fr-FR')})</h3><img src="${e.photo}" alt="Justificatif ${i+1}" /></div>`)
+      .join("");
+    const photosSection = photosHtml ? `<div class="page-break"></div><h2>Justificatifs</h2>${photosHtml}` : "";
+
+    const printWindow = window.open("", "_blank");
+    if (!printWindow) return;
+    printWindow.document.write(`<!DOCTYPE html><html><head><title>Services à la personne ${title}</title><style>
+        body{font-family:Arial,sans-serif;padding:20px;}
+        table{width:100%;border-collapse:collapse;margin-top:20px;}
+        th,td{border:1px solid #000;padding:8px;text-align:left;}
+        h1{margin-bottom:10px;}
+        h2{margin-top:40px;}
+        img{max-width:100%;height:auto;margin-top:8px;}
+        .receipt-photo{margin-bottom:20px;}
+        @media print { .page-break { page-break-before: always; } }
+      </style></head><body>
+        <h1>Services à la personne ${title}</h1>
+        <p><strong>Total services à domicile (case 7DB) :</strong> ${homeTotal.toLocaleString('fr-FR')} €</p>
+        <p><strong>Total garde d'enfants hors domicile (case 7DF) :</strong> ${childTotal.toLocaleString('fr-FR')} €</p>
+        ${childLines ? `<h2>Ventilation par enfant (cases 7GA à 7GG)</h2>${childLines}` : ''}
+        <p><strong>Crédit d'impôt estimé (50%) :</strong> ${credit.toLocaleString('fr-FR')} €</p>
+        <p>Document justificatif à présenter à l'administration fiscale en cas de contrôle.</p>
+        <table><thead><tr><th>Date</th><th>Nature</th><th>Prestataire</th><th>Dépense</th><th>Aides</th><th>Net</th></tr></thead><tbody>${rows}</tbody></table>
+        ${photosSection}
+      </body></html>`);
+    printWindow.document.close();
+    printWindow.focus();
+    printWindow.print();
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <main className="container mx-auto px-4 py-8 space-y-8">
+        <ServicesDashboard expenses={filtered} selectedYear={selectedYear} />
+
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <Input
+            placeholder="Rechercher un prestataire ou une nature"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="max-w-md"
+          />
+          <div className="flex gap-2">
+            <Select value={selectedYear} onValueChange={setSelectedYear}>
+              <SelectTrigger className="w-[180px]">
+                <SelectValue placeholder="Année" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Toutes</SelectItem>
+                {years.map((year) => (
+                  <SelectItem key={year} value={year}>
+                    {year}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button onClick={handleDownloadPDF}>Exporter PDF</Button>
+          </div>
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-2">
+          <div>
+            <AddServiceForm
+              onAdd={handleAdd}
+              initialData={editing || undefined}
+              onUpdate={handleUpdate}
+              onCancelEdit={() => setEditing(null)}
+            />
+          </div>
+          <div>
+            <ServicesList
+              expenses={filtered}
+              onDelete={handleDelete}
+              onEdit={(e) => setEditing(e)}
+              onUpdatePhoto={handleUpdatePhoto}
+            />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default Services;

--- a/src/types/ServiceExpense.ts
+++ b/src/types/ServiceExpense.ts
@@ -1,0 +1,13 @@
+export interface ServiceExpense {
+  id: string;
+  date: string; // Format YYYY-MM-DD
+  category: 'home' | 'childcare';
+  nature: string;
+  provider: string;
+  amount: number; // Dépense totale engagée
+  aids: number; // Aides perçues à déduire
+  childName?: string;
+  childBirthDate?: string; // Format YYYY-MM-DD
+  photo?: string | null;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- note in PDF export that total donations go in box 7UF
- add navigation and new page for services à la personne with form, list, dashboard and PDF

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b1b254a5ec8321bafca5ad0395cbac