### PR TITLE
feat: add overview and donations page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import Donations from "./pages/Donations";
 import Services from "./pages/Services";
 import NotFound from "./pages/NotFound";
 
@@ -17,6 +18,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/donations" element={<Donations />} />
           <Route path="/services" element={<Services />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -19,9 +19,7 @@ const Dashboard = ({ receipts, selectedYear }: DashboardProps) => {
         <h2 className="text-3xl font-bold text-foreground mb-2">
           {displayYear === 'Toutes' ? 'Toutes années' : `Année ${displayYear}`}
         </h2>
-        <p className="text-muted-foreground">
-          Votre synthèse fiscale en temps réel
-        </p>
+        <p className="text-muted-foreground">Synthèse des dons 66%</p>
       </div>
 
       <div className="grid gap-4 md:grid-cols-3">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,8 +15,24 @@ const Header = () => {
             </div>
           </div>
           <nav className="flex gap-4">
-            <Link to="/" className={`text-sm font-medium hover:underline ${location.pathname === '/' ? 'text-primary' : 'text-foreground'}`}>Dons 66%</Link>
-            <Link to="/services" className={`text-sm font-medium hover:underline ${location.pathname === '/services' ? 'text-primary' : 'text-foreground'}`}>Services à la personne</Link>
+            <Link
+              to="/"
+              className={`text-sm font-medium hover:underline ${location.pathname === '/' ? 'text-primary' : 'text-foreground'}`}
+            >
+              Aperçu
+            </Link>
+            <Link
+              to="/donations"
+              className={`text-sm font-medium hover:underline ${location.pathname === '/donations' ? 'text-primary' : 'text-foreground'}`}
+            >
+              Dons 66%
+            </Link>
+            <Link
+              to="/services"
+              className={`text-sm font-medium hover:underline ${location.pathname === '/services' ? 'text-primary' : 'text-foreground'}`}
+            >
+              Services à la personne
+            </Link>
           </nav>
         </div>
       </div>

--- a/src/pages/Donations.tsx
+++ b/src/pages/Donations.tsx
@@ -1,0 +1,211 @@
+import { useState, useEffect } from "react";
+import { Receipt as ReceiptType } from "@/types/Receipt";
+import Header from "@/components/Header";
+import Dashboard from "@/components/Dashboard";
+import AddReceiptForm from "@/components/AddReceiptForm";
+import ReceiptsList from "@/components/ReceiptsList";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+
+const Donations = () => {
+  const [receipts, setReceipts] = useState<ReceiptType[]>([]);
+  const [editingReceipt, setEditingReceipt] = useState<ReceiptType | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedYear, setSelectedYear] = useState("all");
+  const { toast } = useToast();
+
+  // Load receipts from localStorage on component mount
+  useEffect(() => {
+    const storedReceipts = localStorage.getItem('pimpo-receipts');
+    if (storedReceipts) {
+      try {
+        setReceipts(JSON.parse(storedReceipts));
+      } catch (error) {
+        console.error('Error loading receipts from localStorage:', error);
+      }
+    } else {
+      // Add some sample data for demonstration
+      const sampleReceipts: ReceiptType[] = [
+        {
+          id: "1",
+          date: "2024-12-15",
+          organism: "Médecins Sans Frontières",
+          amount: 150,
+          createdAt: new Date().toISOString()
+        },
+        {
+          id: "2", 
+          date: "2024-11-20",
+          organism: "Restos du Cœur",
+          amount: 75,
+          createdAt: new Date().toISOString()
+        },
+        {
+          id: "3",
+          date: "2024-10-05",
+          organism: "Croix-Rouge Française", 
+          amount: 200,
+          createdAt: new Date().toISOString()
+        }
+      ];
+      setReceipts(sampleReceipts);
+    }
+  }, []);
+
+  // Save receipts to localStorage whenever receipts change
+  useEffect(() => {
+    localStorage.setItem('pimpo-receipts', JSON.stringify(receipts));
+  }, [receipts]);
+
+  const handleAddReceipt = (newReceipt: ReceiptType) => {
+    setReceipts(prev => [...prev, newReceipt]);
+  };
+
+  const handleUpdateReceipt = (updated: ReceiptType) => {
+    setReceipts(prev => prev.map(r => (r.id === updated.id ? updated : r)));
+    setEditingReceipt(null);
+  };
+
+  const handleDeleteReceipt = (id: string) => {
+    setReceipts(prev => prev.filter(r => r.id !== id));
+  };
+
+  const handleUpdateReceiptPhoto = (id: string, photo: string | null) => {
+    setReceipts(prev => prev.map(r => (r.id === id ? { ...r, photo: photo || undefined } : r)));
+  };
+
+  const years = Array.from(new Set(receipts.map(r => r.date.slice(0, 4)))).sort().reverse();
+
+  const filteredReceipts = receipts.filter((r) => {
+    const matchesYear = selectedYear === "all" || r.date.startsWith(selectedYear);
+    const matchesSearch = r.organism.toLowerCase().includes(searchTerm.toLowerCase());
+    return matchesYear && matchesSearch;
+  });
+
+  const handleDownloadPDF = () => {
+    if (filteredReceipts.length === 0) {
+      toast({
+        title: "Aucun reçu",
+        description: "Aucun reçu trouvé pour l'année sélectionnée.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const title = selectedYear === "all" ? "Toutes années" : `Année ${selectedYear}`;
+    const totalAmount = filteredReceipts.reduce((sum, r) => sum + r.amount, 0);
+    const taxReduction = Math.round(totalAmount * 0.66);
+
+    const rows = filteredReceipts
+      .map(
+        (r) =>
+          `<tr><td>${new Date(r.date).toLocaleDateString('fr-FR')}</td><td>${r.organism}</td><td>${r.amount.toLocaleString('fr-FR')} €</td></tr>`
+      )
+      .join("");
+
+    const photosHtml = filteredReceipts
+      .filter((r) => r.photo)
+      .map(
+        (r, i) =>
+          `<div class="receipt-photo"><h3>Reçu ${i + 1} - ${r.organism} (${new Date(r.date).toLocaleDateString('fr-FR')})</h3><img src="${r.photo}" alt="Reçu ${i + 1}" /></div>`
+      )
+      .join("");
+
+    const photosSection = photosHtml
+      ? `<div class="page-break"></div><h2>Photos des reçus fiscaux</h2>${photosHtml}`
+      : "";
+
+    const printWindow = window.open("", "_blank");
+    if (!printWindow) return;
+    printWindow.document.write(`<!DOCTYPE html><html><head><title>Reçus fiscaux ${title}</title><style>
+        body{font-family:Arial,sans-serif;padding:20px;}
+        table{width:100%;border-collapse:collapse;margin-top:20px;}
+        th,td{border:1px solid #000;padding:8px;text-align:left;}
+        h1{margin-bottom:10px;}
+        h2{margin-top:40px;}
+        img{max-width:100%;height:auto;margin-top:8px;}
+        .receipt-photo{margin-bottom:20px;}
+        @media print { .page-break { page-break-before: always; } }
+      </style></head><body>
+        <h1>Reçus fiscaux ${title}</h1>
+        <p><strong>Montant total des dons :</strong> ${totalAmount.toLocaleString('fr-FR')} €</p>
+        <p>Le montant total des dons de l'année est à saisir dans la case 7UF de la déclaration d'impôts.</p>
+        <p><strong>Réduction fiscale (66%) :</strong> ${taxReduction.toLocaleString('fr-FR')} €</p>
+        <p>Document justificatif à présenter à l'administration fiscale en cas de contrôle.</p>
+        <table><thead><tr><th>Date</th><th>Organisme</th><th>Montant</th></tr></thead><tbody>${rows}</tbody></table>
+        ${photosSection}
+      </body></html>`);
+    printWindow.document.close();
+    printWindow.focus();
+    printWindow.print();
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+
+        <main className="container mx-auto px-4 py-8 space-y-8">
+          <div className="text-center py-6">
+            <h2 className="text-3xl font-bold text-foreground mb-2">Dons 66%</h2>
+            <p className="text-muted-foreground">Gérez vos reçus et réductions</p>
+          </div>
+          <Dashboard receipts={filteredReceipts} selectedYear={selectedYear} />
+
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <Input
+              placeholder="Rechercher un organisme"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="max-w-md"
+            />
+            <div className="flex gap-2">
+              <Select value={selectedYear} onValueChange={setSelectedYear}>
+                <SelectTrigger className="w-[180px]">
+                  <SelectValue placeholder="Année" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Toutes</SelectItem>
+                  {years.map((year) => (
+                    <SelectItem key={year} value={year}>
+                      {year}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button onClick={handleDownloadPDF}>Exporter PDF</Button>
+            </div>
+          </div>
+
+          <div className="grid gap-8 lg:grid-cols-2">
+            <div>
+              <AddReceiptForm
+                onAddReceipt={handleAddReceipt}
+                initialData={editingReceipt || undefined}
+                onUpdateReceipt={handleUpdateReceipt}
+                onCancelEdit={() => setEditingReceipt(null)}
+              />
+            </div>
+
+            <div>
+              <ReceiptsList
+                receipts={filteredReceipts}
+                onDeleteReceipt={handleDeleteReceipt}
+                onEditReceipt={(receipt) => setEditingReceipt(receipt)}
+                onUpdatePhoto={handleUpdateReceiptPhoto}
+              />
+            </div>
+          </div>
+        </main>
+      </div>
+    );
+  };
+
+export default Donations;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,201 +1,98 @@
-import { useState, useEffect } from "react";
-import { Receipt as ReceiptType } from "@/types/Receipt";
+import { useEffect, useState } from "react";
 import Header from "@/components/Header";
 import Dashboard from "@/components/Dashboard";
-import AddReceiptForm from "@/components/AddReceiptForm";
-import ReceiptsList from "@/components/ReceiptsList";
-import { Input } from "@/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Button } from "@/components/ui/button";
-import { useToast } from "@/hooks/use-toast";
+import ServicesDashboard from "@/components/ServicesDashboard";
+import { Receipt } from "@/types/Receipt";
+import { ServiceExpense } from "@/types/ServiceExpense";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 const Index = () => {
-  const [receipts, setReceipts] = useState<ReceiptType[]>([]);
-  const [editingReceipt, setEditingReceipt] = useState<ReceiptType | null>(null);
-  const [searchTerm, setSearchTerm] = useState("");
+  const [receipts, setReceipts] = useState<Receipt[]>([]);
+  const [expenses, setExpenses] = useState<ServiceExpense[]>([]);
   const [selectedYear, setSelectedYear] = useState("all");
-  const { toast } = useToast();
 
-  // Load receipts from localStorage on component mount
   useEffect(() => {
-    const storedReceipts = localStorage.getItem('pimpo-receipts');
+    const storedReceipts = localStorage.getItem("pimpo-receipts");
     if (storedReceipts) {
       try {
         setReceipts(JSON.parse(storedReceipts));
-      } catch (error) {
-        console.error('Error loading receipts from localStorage:', error);
+      } catch (e) {
+        console.error("Error loading receipts from localStorage:", e);
       }
-    } else {
-      // Add some sample data for demonstration
-      const sampleReceipts: ReceiptType[] = [
-        {
-          id: "1",
-          date: "2024-12-15",
-          organism: "Médecins Sans Frontières",
-          amount: 150,
-          createdAt: new Date().toISOString()
-        },
-        {
-          id: "2", 
-          date: "2024-11-20",
-          organism: "Restos du Cœur",
-          amount: 75,
-          createdAt: new Date().toISOString()
-        },
-        {
-          id: "3",
-          date: "2024-10-05",
-          organism: "Croix-Rouge Française", 
-          amount: 200,
-          createdAt: new Date().toISOString()
-        }
-      ];
-      setReceipts(sampleReceipts);
+    }
+
+    const storedServices = localStorage.getItem("pimpo-services");
+    if (storedServices) {
+      try {
+        setExpenses(JSON.parse(storedServices));
+      } catch (e) {
+        console.error("Error loading services from localStorage:", e);
+      }
     }
   }, []);
 
-  // Save receipts to localStorage whenever receipts change
-  useEffect(() => {
-    localStorage.setItem('pimpo-receipts', JSON.stringify(receipts));
-  }, [receipts]);
+  const years = Array.from(
+    new Set([
+      ...receipts.map((r) => r.date.slice(0, 4)),
+      ...expenses.map((e) => e.date.slice(0, 4)),
+    ])
+  )
+    .sort()
+    .reverse();
 
-  const handleAddReceipt = (newReceipt: ReceiptType) => {
-    setReceipts(prev => [...prev, newReceipt]);
-  };
-
-  const handleUpdateReceipt = (updated: ReceiptType) => {
-    setReceipts(prev => prev.map(r => (r.id === updated.id ? updated : r)));
-    setEditingReceipt(null);
-  };
-
-  const handleDeleteReceipt = (id: string) => {
-    setReceipts(prev => prev.filter(r => r.id !== id));
-  };
-
-  const handleUpdateReceiptPhoto = (id: string, photo: string | null) => {
-    setReceipts(prev => prev.map(r => (r.id === id ? { ...r, photo: photo || undefined } : r)));
-  };
-
-  const years = Array.from(new Set(receipts.map(r => r.date.slice(0, 4)))).sort().reverse();
-
-  const filteredReceipts = receipts.filter((r) => {
-    const matchesYear = selectedYear === "all" || r.date.startsWith(selectedYear);
-    const matchesSearch = r.organism.toLowerCase().includes(searchTerm.toLowerCase());
-    return matchesYear && matchesSearch;
-  });
-
-  const handleDownloadPDF = () => {
-    if (filteredReceipts.length === 0) {
-      toast({
-        title: "Aucun reçu",
-        description: "Aucun reçu trouvé pour l'année sélectionnée.",
-        variant: "destructive",
-      });
-      return;
-    }
-
-    const title = selectedYear === "all" ? "Toutes années" : `Année ${selectedYear}`;
-    const totalAmount = filteredReceipts.reduce((sum, r) => sum + r.amount, 0);
-    const taxReduction = Math.round(totalAmount * 0.66);
-
-    const rows = filteredReceipts
-      .map(
-        (r) =>
-          `<tr><td>${new Date(r.date).toLocaleDateString('fr-FR')}</td><td>${r.organism}</td><td>${r.amount.toLocaleString('fr-FR')} €</td></tr>`
-      )
-      .join("");
-
-    const photosHtml = filteredReceipts
-      .filter((r) => r.photo)
-      .map(
-        (r, i) =>
-          `<div class="receipt-photo"><h3>Reçu ${i + 1} - ${r.organism} (${new Date(r.date).toLocaleDateString('fr-FR')})</h3><img src="${r.photo}" alt="Reçu ${i + 1}" /></div>`
-      )
-      .join("");
-
-    const photosSection = photosHtml
-      ? `<div class="page-break"></div><h2>Photos des reçus fiscaux</h2>${photosHtml}`
-      : "";
-
-    const printWindow = window.open("", "_blank");
-    if (!printWindow) return;
-    printWindow.document.write(`<!DOCTYPE html><html><head><title>Reçus fiscaux ${title}</title><style>
-        body{font-family:Arial,sans-serif;padding:20px;}
-        table{width:100%;border-collapse:collapse;margin-top:20px;}
-        th,td{border:1px solid #000;padding:8px;text-align:left;}
-        h1{margin-bottom:10px;}
-        h2{margin-top:40px;}
-        img{max-width:100%;height:auto;margin-top:8px;}
-        .receipt-photo{margin-bottom:20px;}
-        @media print { .page-break { page-break-before: always; } }
-      </style></head><body>
-        <h1>Reçus fiscaux ${title}</h1>
-        <p><strong>Montant total des dons :</strong> ${totalAmount.toLocaleString('fr-FR')} €</p>
-        <p>Le montant total des dons de l'année est à saisir dans la case 7UF de la déclaration d'impôts.</p>
-        <p><strong>Réduction fiscale (66%) :</strong> ${taxReduction.toLocaleString('fr-FR')} €</p>
-        <p>Document justificatif à présenter à l'administration fiscale en cas de contrôle.</p>
-        <table><thead><tr><th>Date</th><th>Organisme</th><th>Montant</th></tr></thead><tbody>${rows}</tbody></table>
-        ${photosSection}
-      </body></html>`);
-    printWindow.document.close();
-    printWindow.focus();
-    printWindow.print();
-  };
+  const filteredReceipts = receipts.filter(
+    (r) => selectedYear === "all" || r.date.startsWith(selectedYear)
+  );
+  const filteredExpenses = expenses.filter(
+    (e) => selectedYear === "all" || e.date.startsWith(selectedYear)
+  );
 
   return (
     <div className="min-h-screen bg-background">
       <Header />
-      
-        <main className="container mx-auto px-4 py-8 space-y-8">
-          <Dashboard receipts={filteredReceipts} selectedYear={selectedYear} />
+      <main className="container mx-auto px-4 py-8 space-y-8">
+        <div className="text-center py-6">
+          <h2 className="text-3xl font-bold text-foreground mb-2">Aperçu global</h2>
+          <p className="text-muted-foreground">
+            Synthèse des dons 66% et des services à la personne
+          </p>
+        </div>
 
-          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-            <Input
-              placeholder="Rechercher un organisme"
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="max-w-md"
-            />
-            <div className="flex gap-2">
-              <Select value={selectedYear} onValueChange={setSelectedYear}>
-                <SelectTrigger className="w-[180px]">
-                  <SelectValue placeholder="Année" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">Toutes</SelectItem>
-                  {years.map((year) => (
-                    <SelectItem key={year} value={year}>
-                      {year}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <Button onClick={handleDownloadPDF}>Exporter PDF</Button>
-            </div>
-          </div>
+        <div className="flex justify-center">
+          <Select value={selectedYear} onValueChange={setSelectedYear}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Année" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Toutes</SelectItem>
+              {years.map((year) => (
+                <SelectItem key={year} value={year}>
+                  {year}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
 
-          <div className="grid gap-8 lg:grid-cols-2">
-            <div>
-              <AddReceiptForm
-                onAddReceipt={handleAddReceipt}
-                initialData={editingReceipt || undefined}
-                onUpdateReceipt={handleUpdateReceipt}
-                onCancelEdit={() => setEditingReceipt(null)}
-              />
-            </div>
+        <Dashboard receipts={filteredReceipts} selectedYear={selectedYear} />
+        <p className="text-sm text-muted-foreground text-center">
+          Le montant total des dons de l'année est à déclarer en case 7UF.
+        </p>
 
-            <div>
-              <ReceiptsList
-                receipts={filteredReceipts}
-                onDeleteReceipt={handleDeleteReceipt}
-                onEditReceipt={(receipt) => setEditingReceipt(receipt)}
-                onUpdatePhoto={handleUpdateReceiptPhoto}
-              />
-            </div>
-          </div>
-        </main>
-      </div>
-    );
-  };
+        <ServicesDashboard expenses={filteredExpenses} selectedYear={selectedYear} />
+        <p className="text-sm text-muted-foreground text-center">
+          Reportez les services à domicile en case 7DB, la garde d'enfants hors domicile en case 7DF, et les montants par enfant en cases 7GA à 7GG.
+        </p>
+      </main>
+    </div>
+  );
+};
 
 export default Index;
+

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -120,6 +120,10 @@ const Services = () => {
     <div className="min-h-screen bg-background">
       <Header />
       <main className="container mx-auto px-4 py-8 space-y-8">
+        <div className="text-center py-6">
+          <h2 className="text-3xl font-bold text-foreground mb-2">Services à la personne</h2>
+          <p className="text-muted-foreground">Suivez vos dépenses et crédits</p>
+        </div>
         <ServicesDashboard expenses={filtered} selectedYear={selectedYear} />
 
         <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">


### PR DESCRIPTION
## Summary
- add global overview page combining donations and services
- move 66% donation management into its own page
- update navigation and titles to reflect new structure

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1b905f8f48321b27aff3168e722bf