### PR TITLE
Affiner la page foyer fiscal avec TMI

### DIFF
--- a/src/lib/tax.ts
+++ b/src/lib/tax.ts
@@ -8,18 +8,24 @@ export const calculateParts = (adults: number, children: number): number => {
   return parts;
 };
 
+export interface TaxBracket {
+  limit: number;
+  rate: number;
+}
+
+export const taxBrackets: TaxBracket[] = [
+  { limit: 10777, rate: 0 },
+  { limit: 27478, rate: 0.11 },
+  { limit: 78570, rate: 0.3 },
+  { limit: 168994, rate: 0.41 },
+  { limit: Infinity, rate: 0.45 },
+];
+
 export const calculateIncomeTax = (income: number, parts: number): number => {
   const taxable = income / parts;
-  const brackets = [
-    { limit: 10777, rate: 0 },
-    { limit: 27478, rate: 0.11 },
-    { limit: 78570, rate: 0.30 },
-    { limit: 168994, rate: 0.41 },
-    { limit: Infinity, rate: 0.45 },
-  ];
   let tax = 0;
   let prev = 0;
-  for (const bracket of brackets) {
+  for (const bracket of taxBrackets) {
     if (taxable > bracket.limit) {
       tax += (bracket.limit - prev) * bracket.rate;
       prev = bracket.limit;
@@ -29,4 +35,10 @@ export const calculateIncomeTax = (income: number, parts: number): number => {
     }
   }
   return Math.round(tax * parts);
+};
+
+export const calculateTmi = (income: number, parts: number): number => {
+  const taxable = income / parts;
+  const bracket = taxBrackets.find((b) => taxable <= b.limit);
+  return bracket ? bracket.rate : taxBrackets[taxBrackets.length - 1].rate;
 };

--- a/src/pages/Household.tsx
+++ b/src/pages/Household.tsx
@@ -3,12 +3,22 @@ import Header from "@/components/Header";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, ReferenceLine } from "recharts";
 import { Household } from "@/types/Household";
+import { calculateParts, calculateTmi, taxBrackets } from "@/lib/tax";
 import { useToast } from "@/hooks/use-toast";
 
 const HouseholdPage = () => {
   const { toast } = useToast();
   const [data, setData] = useState<Household>({
+    status: "marie",
     members: [
       { name: "", salary: 0 },
       { name: "", salary: 0 },
@@ -20,7 +30,8 @@ const HouseholdPage = () => {
     const stored = localStorage.getItem("pimpo-household");
     if (stored) {
       try {
-        setData(JSON.parse(stored));
+        const parsed = JSON.parse(stored);
+        setData({ status: "marie", ...parsed });
       } catch (e) {
         console.error("Error loading household from localStorage:", e);
       }
@@ -48,6 +59,21 @@ const HouseholdPage = () => {
     toast({ title: "Foyer sauvegardé" });
   };
 
+  const totalIncome = data.members.reduce((s, m) => s + (m.salary || 0), 0);
+  const adults =
+    data.status === "concubinage"
+      ? 1
+      : Math.max(1, data.members.filter((m) => m.name || m.salary).length);
+  const parts = calculateParts(adults, data.children);
+  const tmi = calculateTmi(totalIncome, parts);
+  const taxable = totalIncome / parts;
+  const chartData = [
+    { income: 0, rate: 0 },
+    ...taxBrackets
+      .filter((b) => b.limit !== Infinity)
+      .map((b) => ({ income: b.limit, rate: b.rate * 100 })),
+  ];
+
   return (
     <div className="min-h-screen bg-background">
       <Header />
@@ -63,28 +89,108 @@ const HouseholdPage = () => {
           </CardHeader>
           <CardContent className="space-y-4">
             {data.members.map((m, i) => (
-              <div key={i} className="grid gap-2 md:grid-cols-2">
-                <Input
-                  placeholder={`Nom de la personne ${i + 1}`}
-                  value={m.name}
-                  onChange={(e) => handleChangeMember(i, "name", e.target.value)}
-                />
-                <Input
-                  type="number"
-                  placeholder="Salaire net annuel (€)"
-                  value={m.salary || ""}
-                  onChange={(e) => handleChangeMember(i, "salary", e.target.value)}
-                />
+              <div key={i} className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-1">
+                  <Label htmlFor={`name-${i}`}>{`Nom de la personne ${i + 1}`}</Label>
+                  <Input
+                    id={`name-${i}`}
+                    placeholder="Jean Dupont"
+                    value={m.name}
+                    onChange={(e) => handleChangeMember(i, "name", e.target.value)}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor={`salary-${i}`}>Salaire net annuel estimé (€)</Label>
+                  <Input
+                    id={`salary-${i}`}
+                    type="number"
+                    placeholder="30000"
+                    value={m.salary || ""}
+                    onChange={(e) => handleChangeMember(i, "salary", e.target.value)}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Montant net perçu sur l'année, après cotisations sociales.
+                  </p>
+                </div>
               </div>
             ))}
-            <Input
-              type="number"
-              placeholder="Nombre d'enfants à charge"
-              value={data.children}
-              onChange={(e) =>
-                setData((prev) => ({ ...prev, children: Number(e.target.value) }))
-              }
-            />
+            <div className="space-y-1">
+              <Label htmlFor="children">Nombre d'enfants à charge</Label>
+              <Input
+                id="children"
+                type="number"
+                placeholder="0"
+                value={data.children}
+                onChange={(e) =>
+                  setData((prev) => ({ ...prev, children: Number(e.target.value) }))
+                }
+              />
+              <p className="text-xs text-muted-foreground">
+                Enfants rattachés fiscalement au foyer.
+              </p>
+            </div>
+            <div className="space-y-2 pt-2">
+              <Label>Situation familiale</Label>
+              <RadioGroup
+                className="flex gap-4"
+                value={data.status}
+                onValueChange={(val) =>
+                  setData((prev) => ({ ...prev, status: val as Household["status"] }))
+                }
+              >
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="marie" id="marie" />
+                  <Label htmlFor="marie">Marié</Label>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="pacse" id="pacse" />
+                  <Label htmlFor="pacse">Pacsé</Label>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="concubinage" id="concubinage" />
+                  <Label htmlFor="concubinage">Concubinage</Label>
+                </div>
+              </RadioGroup>
+              <p className="text-xs text-muted-foreground">
+                Sélectionnez votre statut pour le calcul des parts fiscales.
+              </p>
+            </div>
+            {totalIncome > 0 && (
+              <div className="space-y-4 pt-4">
+                <p className="text-center font-medium">
+                  Taux marginal d'imposition : {(tmi * 100).toFixed(0)}%
+                </p>
+                <ChartContainer
+                  config={{ rate: { label: "TMI", color: "hsl(var(--primary))" } }}
+                  className="h-64"
+                >
+                  <LineChart data={chartData}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis
+                      dataKey="income"
+                      tickFormatter={(v) => v.toLocaleString("fr-FR")}
+                      label={{ value: "Revenu par part (€)", position: "insideBottom", dy: 10 }}
+                    />
+                    <YAxis
+                      dataKey="rate"
+                      tickFormatter={(v) => `${v}%`}
+                      label={{ value: "TMI", angle: -90, position: "insideLeft" }}
+                    />
+                    <ReferenceLine x={taxable} stroke="red" strokeDasharray="3 3" />
+                    <Line
+                      type="stepAfter"
+                      dataKey="rate"
+                      stroke="var(--color-rate)"
+                      dot={false}
+                    />
+                    <ChartTooltip content={<ChartTooltipContent />} />
+                  </LineChart>
+                </ChartContainer>
+                <p className="text-xs text-muted-foreground text-center">
+                  Ligne rouge : votre revenu par part fiscale.
+                </p>
+              </div>
+            )}
             <Button onClick={handleSave} className="w-full">
               Sauvegarder
             </Button>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -43,7 +43,8 @@ const Index = () => {
     const storedHousehold = localStorage.getItem("pimpo-household");
     if (storedHousehold) {
       try {
-        setHousehold(JSON.parse(storedHousehold));
+        const parsed: Household = JSON.parse(storedHousehold);
+        setHousehold({ status: "marie", ...parsed });
       } catch (e) {
         console.error("Error loading household from localStorage:", e);
       }
@@ -76,10 +77,13 @@ const Index = () => {
   let remainingPercent = 100;
 
   if (household) {
-    const adults = Math.max(
-      1,
-      household.members.filter((m) => m.name || m.salary).length
-    );
+    const adults =
+      household.status === "concubinage"
+        ? 1
+        : Math.max(
+            1,
+            household.members.filter((m) => m.name || m.salary).length
+          );
     const totalIncome = household.members.reduce((s, m) => s + (m.salary || 0), 0);
     const parts = calculateParts(adults, household.children);
     incomeTax = calculateIncomeTax(totalIncome, parts);

--- a/src/types/Household.ts
+++ b/src/types/Household.ts
@@ -3,7 +3,10 @@ export interface HouseholdMember {
   salary: number; // Net annual salary
 }
 
+export type MaritalStatus = "marie" | "pacse" | "concubinage";
+
 export interface Household {
+  status: MaritalStatus; // Marital situation
   members: HouseholdMember[]; // Adults in the household
   children: number; // Number of dependent children
 }


### PR DESCRIPTION
## Summary
- Add marital status to household model and tax brackets utilities
- Clarify income and children inputs on household page with labels and hints
- Show marginal tax rate and chart, with option to choose marital situation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2e725ce2c8321b8a33f466b943118