### PR TITLE
feat: add mobile bottom navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Donations from "./pages/Donations";
 import Services from "./pages/Services";
 import NotFound from "./pages/NotFound";
 import HouseholdPage from "./pages/Household";
+import MobileNav from "./components/MobileNav";
 
 const queryClient = new QueryClient();
 
@@ -25,6 +26,7 @@ const App = () => (
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>
+        <MobileNav />
       </BrowserRouter>
     </TooltipProvider>
   </QueryClientProvider>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,7 +14,7 @@ const Header = () => {
               <p className="text-sm text-muted-foreground">Pour pimper votre déclaration d'impôts</p>
             </div>
           </div>
-          <nav className="flex gap-4">
+          <nav className="hidden gap-4 sm:flex">
             <Link
               to="/"
               className={`text-sm font-medium hover:underline ${location.pathname === '/' ? 'text-primary' : 'text-foreground'}`}

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,0 +1,31 @@
+import { Home, Users, HandCoins, HandPlatter } from "lucide-react";
+import { Link, useLocation } from "react-router-dom";
+
+const MobileNav = () => {
+  const location = useLocation();
+  const items = [
+    { to: "/", icon: Home, label: "Aperçu" },
+    { to: "/foyer", icon: Users, label: "Foyer fiscal" },
+    { to: "/donations", icon: HandCoins, label: "Dons 66%" },
+    { to: "/services", icon: HandPlatter, label: "Services" },
+  ];
+
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 flex justify-around border-t border-border bg-card py-2 sm:hidden">
+      {items.map(({ to, icon: Icon, label }) => (
+        <Link
+          key={to}
+          to={to}
+          className={`flex flex-col items-center ${
+            location.pathname === to ? "text-primary" : "text-muted-foreground"
+          }`}
+        >
+          <Icon className="h-6 w-6" />
+          <span className="sr-only">{label}</span>
+        </Link>
+      ))}
+    </nav>
+  );
+};
+
+export default MobileNav;

--- a/src/pages/Donations.tsx
+++ b/src/pages/Donations.tsx
@@ -152,7 +152,7 @@ const Donations = () => {
     <div className="min-h-screen bg-background">
       <Header />
 
-        <main className="container mx-auto px-4 py-8 space-y-8">
+        <main className="container mx-auto px-4 py-8 pb-24 space-y-8">
           <div className="text-center py-6">
             <h2 className="text-3xl font-bold text-foreground mb-2">Dons 66%</h2>
             <p className="text-muted-foreground">Gérez vos reçus et réductions</p>

--- a/src/pages/Household.tsx
+++ b/src/pages/Household.tsx
@@ -77,7 +77,7 @@ const HouseholdPage = () => {
   return (
     <div className="min-h-screen bg-background">
       <Header />
-      <main className="container mx-auto px-4 py-8 space-y-8">
+      <main className="container mx-auto px-4 py-8 pb-24 space-y-8">
         <div className="text-center py-6">
           <h2 className="text-3xl font-bold text-foreground mb-2">Foyer fiscal</h2>
           <p className="text-muted-foreground">Identité et revenus du foyer</p>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -96,7 +96,7 @@ const Index = () => {
   return (
     <div className="min-h-screen bg-background">
       <Header />
-      <main className="container mx-auto px-4 py-8 space-y-8">
+      <main className="container mx-auto px-4 py-8 pb-24 space-y-8">
         <div className="text-center py-6">
           <h2 className="text-3xl font-bold text-foreground mb-2">Aperçu global</h2>
           <p className="text-muted-foreground">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -12,7 +12,7 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="min-h-screen pb-24 flex items-center justify-center bg-gray-100">
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -119,7 +119,7 @@ const Services = () => {
   return (
     <div className="min-h-screen bg-background">
       <Header />
-      <main className="container mx-auto px-4 py-8 space-y-8">
+      <main className="container mx-auto px-4 py-8 pb-24 space-y-8">
         <div className="text-center py-6">
           <h2 className="text-3xl font-bold text-foreground mb-2">Services à la personne</h2>
           <p className="text-muted-foreground">Suivez vos dépenses et crédits</p>


### PR DESCRIPTION
## Summary
- add icon-only mobile nav bar and hide header links on small screens
- render mobile nav globally and add bottom spacing to pages

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b348bea3fc8321a44d412069a5c699