### PR TITLE
Retirer la vue pluriannuelle

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -8,7 +8,6 @@ interface DashboardProps {
 }
 
 const Dashboard = ({ receipts, selectedYear }: DashboardProps) => {
-  const displayYear = selectedYear === 'all' ? 'Toutes' : selectedYear;
 
   const totalAmount = receipts.reduce((sum, receipt) => sum + receipt.amount, 0);
   const taxReduction = Math.round(totalAmount * 0.66);
@@ -17,7 +16,7 @@ const Dashboard = ({ receipts, selectedYear }: DashboardProps) => {
     <div className="space-y-6">
       <div className="text-center py-6">
         <h2 className="text-3xl font-bold text-foreground mb-2">
-          {displayYear === 'Toutes' ? 'Toutes années' : `Année ${displayYear}`}
+          Année {selectedYear}
         </h2>
         <p className="text-muted-foreground">Synthèse des dons 66%</p>
       </div>
@@ -31,7 +30,7 @@ const Dashboard = ({ receipts, selectedYear }: DashboardProps) => {
             <CardContent>
               <div className="text-2xl font-bold">{receipts.length}</div>
               <p className="text-xs text-muted-foreground">
-                reçu{receipts.length > 1 ? 's' : ''} {displayYear === 'Toutes' ? 'au total' : 'cette année'}
+                reçu{receipts.length > 1 ? 's' : ''} cette année
               </p>
             </CardContent>
           </Card>

--- a/src/components/ServicesDashboard.tsx
+++ b/src/components/ServicesDashboard.tsx
@@ -8,7 +8,6 @@ interface ServicesDashboardProps {
 }
 
 const ServicesDashboard = ({ expenses, selectedYear }: ServicesDashboardProps) => {
-  const displayYear = selectedYear === 'all' ? 'Toutes' : selectedYear;
   const net = (e: ServiceExpense) => e.amount - e.aids;
 
   const homeTotal = expenses
@@ -32,7 +31,7 @@ const ServicesDashboard = ({ expenses, selectedYear }: ServicesDashboardProps) =
     <div className="space-y-6">
       <div className="text-center py-6">
         <h2 className="text-3xl font-bold text-foreground mb-2">
-          {displayYear === 'Toutes' ? 'Toutes années' : `Année ${displayYear}`}
+          Année {selectedYear}
         </h2>
         <p className="text-muted-foreground">Synthèse des services à la personne</p>
       </div>

--- a/src/pages/Donations.tsx
+++ b/src/pages/Donations.tsx
@@ -19,7 +19,8 @@ const Donations = () => {
   const [receipts, setReceipts] = useState<ReceiptType[]>([]);
   const [editingReceipt, setEditingReceipt] = useState<ReceiptType | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
-  const [selectedYear, setSelectedYear] = useState("all");
+  const currentYear = new Date().getFullYear().toString();
+  const [selectedYear, setSelectedYear] = useState(currentYear);
   const { toast } = useToast();
 
   // Load receipts from localStorage on component mount
@@ -82,10 +83,10 @@ const Donations = () => {
     setReceipts(prev => prev.map(r => (r.id === id ? { ...r, photo: photo || undefined } : r)));
   };
 
-  const years = Array.from(new Set(receipts.map(r => r.date.slice(0, 4)))).sort().reverse();
+  const years = Array.from(new Set([...receipts.map(r => r.date.slice(0, 4)), currentYear])).sort().reverse();
 
   const filteredReceipts = receipts.filter((r) => {
-    const matchesYear = selectedYear === "all" || r.date.startsWith(selectedYear);
+    const matchesYear = r.date.startsWith(selectedYear);
     const matchesSearch = r.organism.toLowerCase().includes(searchTerm.toLowerCase());
     return matchesYear && matchesSearch;
   });
@@ -100,7 +101,7 @@ const Donations = () => {
       return;
     }
 
-    const title = selectedYear === "all" ? "Toutes années" : `Année ${selectedYear}`;
+    const title = `Année ${selectedYear}`;
     const totalAmount = filteredReceipts.reduce((sum, r) => sum + r.amount, 0);
     const taxReduction = Math.round(totalAmount * 0.66);
 
@@ -172,7 +173,6 @@ const Donations = () => {
                   <SelectValue placeholder="Année" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="all">Toutes</SelectItem>
                   {years.map((year) => (
                     <SelectItem key={year} value={year}>
                       {year}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -18,7 +18,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 const Index = () => {
   const [receipts, setReceipts] = useState<Receipt[]>([]);
   const [expenses, setExpenses] = useState<ServiceExpense[]>([]);
-  const [selectedYear, setSelectedYear] = useState("all");
+  const currentYear = new Date().getFullYear().toString();
+  const [selectedYear, setSelectedYear] = useState(currentYear);
   const [household, setHousehold] = useState<Household | null>(null);
 
   useEffect(() => {
@@ -55,17 +56,14 @@ const Index = () => {
     new Set([
       ...receipts.map((r) => r.date.slice(0, 4)),
       ...expenses.map((e) => e.date.slice(0, 4)),
+      currentYear,
     ])
   )
     .sort()
     .reverse();
 
-  const filteredReceipts = receipts.filter(
-    (r) => selectedYear === "all" || r.date.startsWith(selectedYear)
-  );
-  const filteredExpenses = expenses.filter(
-    (e) => selectedYear === "all" || e.date.startsWith(selectedYear)
-  );
+  const filteredReceipts = receipts.filter((r) => r.date.startsWith(selectedYear));
+  const filteredExpenses = expenses.filter((e) => e.date.startsWith(selectedYear));
 
   const totalDonations = filteredReceipts.reduce((sum, r) => sum + r.amount, 0);
   const donationReduction = Math.round(totalDonations * 0.66);
@@ -110,7 +108,6 @@ const Index = () => {
               <SelectValue placeholder="Année" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="all">Toutes</SelectItem>
               {years.map((year) => (
                 <SelectItem key={year} value={year}>
                   {year}

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -13,7 +13,8 @@ const Services = () => {
   const [expenses, setExpenses] = useState<ServiceExpense[]>([]);
   const [editing, setEditing] = useState<ServiceExpense | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
-  const [selectedYear, setSelectedYear] = useState("all");
+  const currentYear = new Date().getFullYear().toString();
+  const [selectedYear, setSelectedYear] = useState(currentYear);
   const { toast } = useToast();
 
   useEffect(() => {
@@ -41,10 +42,10 @@ const Services = () => {
     setExpenses(prev => prev.map(e => e.id === id ? { ...e, photo: photo || undefined } : e));
   };
 
-  const years = Array.from(new Set(expenses.map(r => r.date.slice(0,4)))).sort().reverse();
+  const years = Array.from(new Set([...expenses.map(r => r.date.slice(0,4)), currentYear])).sort().reverse();
 
   const filtered = expenses.filter((e) => {
-    const matchesYear = selectedYear === "all" || e.date.startsWith(selectedYear);
+    const matchesYear = e.date.startsWith(selectedYear);
     const text = `${e.provider} ${e.nature}`.toLowerCase();
     const matchesSearch = text.includes(searchTerm.toLowerCase());
     return matchesYear && matchesSearch;
@@ -60,7 +61,7 @@ const Services = () => {
       return;
     }
 
-    const title = selectedYear === "all" ? "Toutes années" : `Année ${selectedYear}`;
+    const title = `Année ${selectedYear}`;
     const net = (e: ServiceExpense) => e.amount - e.aids;
     const homeTotal = filtered.filter(e => e.category === 'home').reduce((s,e)=>s+net(e),0);
     const homeCapped = Math.min(homeTotal, 12000);
@@ -139,7 +140,6 @@ const Services = () => {
                 <SelectValue placeholder="Année" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">Toutes</SelectItem>
                 {years.map((year) => (
                   <SelectItem key={year} value={year}>
                     {year}


### PR DESCRIPTION
## Summary
- Supprime l'option de vue pluriannuelle et affiche toujours l'année en cours.
- Filtre dons et services selon l'année courante par défaut.
- Met à jour l'interface pour ne proposer que les années disponibles.

## Testing
- ⚠️ `npm run lint` *(npm absent; tentative d'installation via apt échouée)*

------
https://chatgpt.com/codex/tasks/task_e_68b348ef3fd48321835dc956fdc9fa7b