### PR TITLE
feat: add other income and simplified TMI chart

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -45,7 +45,7 @@ const Index = () => {
     if (storedHousehold) {
       try {
         const parsed: Household = JSON.parse(storedHousehold);
-        setHousehold({ status: "marie", ...parsed });
+        setHousehold({ status: "marie", otherIncome: 0, ...parsed });
       } catch (e) {
         console.error("Error loading household from localStorage:", e);
       }
@@ -82,7 +82,9 @@ const Index = () => {
             1,
             household.members.filter((m) => m.name || m.salary).length
           );
-    const totalIncome = household.members.reduce((s, m) => s + (m.salary || 0), 0);
+    const totalIncome =
+      household.members.reduce((s, m) => s + (m.salary || 0), 0) +
+      (household.otherIncome || 0);
     const parts = calculateParts(adults, household.children);
     incomeTax = calculateIncomeTax(totalIncome, parts);
     reductionApplied = Math.min(donationReduction, incomeTax);

--- a/src/types/Household.ts
+++ b/src/types/Household.ts
@@ -9,4 +9,5 @@ export interface Household {
   status: MaritalStatus; // Marital situation
   members: HouseholdMember[]; // Adults in the household
   children: number; // Number of dependent children
+  otherIncome: number; // Other annual household income
 }


### PR DESCRIPTION
## Summary
- support additional household incomes and display fiscal parts and total income
- simplify TMI visualization with income range slider
- include other income in global dashboard calculations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5673fbb0c8321acc4274cc5dc0b8d