### PR TITLE
feat: track energy transition expenses

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Index from "./pages/Index";
 import Donations from "./pages/Donations";
 import Services from "./pages/Services";
 import Schooling from "./pages/Schooling";
+import Energy from "./pages/Energy";
 import NotFound from "./pages/NotFound";
 import HouseholdPage from "./pages/Household";
 import MobileNav from "./components/MobileNav";
@@ -24,6 +25,7 @@ const App = () => (
           <Route path="/foyer" element={<HouseholdPage />} />
           <Route path="/donations" element={<Donations />} />
           <Route path="/services" element={<Services />} />
+          <Route path="/energie" element={<Energy />} />
           <Route path="/scolarite" element={<Schooling />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />

--- a/src/components/AddEnergyForm.tsx
+++ b/src/components/AddEnergyForm.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { EnergyExpense } from "@/types/EnergyExpense";
+
+interface AddEnergyFormProps {
+  onAdd: (exp: EnergyExpense) => void;
+}
+
+const AddEnergyForm = ({ onAdd }: AddEnergyFormProps) => {
+  const [formData, setFormData] = useState({
+    date: "",
+    category: "isolation",
+    description: "",
+    amount: "",
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formData.date || !formData.category || !formData.amount) return;
+    const newExpense: EnergyExpense = {
+      id: Date.now().toString(),
+      date: formData.date,
+      category: formData.category as 'isolation' | 'equipment',
+      description: formData.description.trim(),
+      amount: parseFloat(formData.amount),
+      createdAt: new Date().toISOString(),
+    };
+    onAdd(newExpense);
+    setFormData({ date: "", category: "isolation", description: "", amount: "" });
+  };
+
+  const handleChange = (field: string, value: string) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Ajouter une dépense</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="date">Date *</Label>
+            <Input id="date" type="date" value={formData.date} onChange={e => handleChange('date', e.target.value)} required />
+          </div>
+          <div className="space-y-2">
+            <Label>Catégorie *</Label>
+            <Select value={formData.category} onValueChange={v => handleChange('category', v)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Choisir" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="isolation">Travaux d'isolation</SelectItem>
+                <SelectItem value="equipment">Équipements économes</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="description">Description</Label>
+            <Input id="description" value={formData.description} onChange={e => handleChange('description', e.target.value)} placeholder="ex: Isolation des combles" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="amount">Montant (€) *</Label>
+            <Input id="amount" type="number" min="0" step="0.01" value={formData.amount} onChange={e => handleChange('amount', e.target.value)} required />
+          </div>
+          <Button type="submit" className="w-full">Enregistrer</Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default AddEnergyForm;
+

--- a/src/components/EnergyDashboard.tsx
+++ b/src/components/EnergyDashboard.tsx
@@ -1,0 +1,58 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EnergyExpense } from "@/types/EnergyExpense";
+import { Leaf, Snowflake, Wrench } from "lucide-react";
+
+interface EnergyDashboardProps {
+  expenses: EnergyExpense[];
+  selectedYear: string;
+}
+
+const EnergyDashboard = ({ expenses, selectedYear }: EnergyDashboardProps) => {
+  const isolationTotal = expenses
+    .filter(e => e.category === 'isolation')
+    .reduce((s, e) => s + e.amount, 0);
+  const equipmentTotal = expenses
+    .filter(e => e.category === 'equipment')
+    .reduce((s, e) => s + e.amount, 0);
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center py-6">
+        <h2 className="text-3xl font-bold text-foreground mb-2">Année {selectedYear}</h2>
+        <p className="text-muted-foreground">Synthèse transition énergétique</p>
+      </div>
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Dépenses enregistrées</CardTitle>
+            <Wrench className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{expenses.length}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Isolation (7AR)</CardTitle>
+            <Snowflake className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{isolationTotal.toLocaleString('fr-FR')} €</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Équipements (7AV)</CardTitle>
+            <Leaf className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{equipmentTotal.toLocaleString('fr-FR')} €</div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default EnergyDashboard;
+

--- a/src/components/EnergyList.tsx
+++ b/src/components/EnergyList.tsx
@@ -1,0 +1,49 @@
+import { EnergyExpense } from "@/types/EnergyExpense";
+import { Card, CardContent, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Trash } from "lucide-react";
+
+interface EnergyListProps {
+  expenses: EnergyExpense[];
+  onDelete: (id: string) => void;
+}
+
+const EnergyList = ({ expenses, onDelete }: EnergyListProps) => {
+  if (expenses.length === 0) {
+    return (
+      <Card>
+        <CardContent className="p-4 text-sm text-muted-foreground text-center">
+          Aucune dépense enregistrée pour cette année.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {expenses.map((e) => (
+        <Card key={e.id}>
+          <CardContent className="flex items-center justify-between p-4">
+            <div>
+              <CardTitle className="text-base">
+                {new Date(e.date).toLocaleDateString('fr-FR')} - {e.description || (e.category === 'isolation' ? 'Travaux d\'isolation' : "Équipement économe")}
+              </CardTitle>
+              <p className="text-sm text-muted-foreground">
+                {e.category === 'isolation' ? 'Case 7AR' : 'Case 7AV'}
+              </p>
+            </div>
+            <div className="flex items-center gap-4">
+              <span className="font-bold">{e.amount.toLocaleString('fr-FR')} €</span>
+              <Button variant="ghost" size="icon" onClick={() => onDelete(e.id)}>
+                <Trash className="h-4 w-4" />
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+export default EnergyList;
+

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -40,6 +40,12 @@ const Header = () => {
               Services à la personne
             </Link>
             <Link
+              to="/energie"
+              className={`text-sm font-medium hover:underline ${location.pathname === '/energie' ? 'text-primary' : 'text-foreground'}`}
+            >
+              Transition énergétique
+            </Link>
+            <Link
               to="/scolarite"
               className={`text-sm font-medium hover:underline ${location.pathname === '/scolarite' ? 'text-primary' : 'text-foreground'}`}
             >

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,4 +1,4 @@
-import { Home, Users, HandCoins, HandPlatter, GraduationCap } from "lucide-react";
+import { Home, Users, HandCoins, HandPlatter, GraduationCap, Leaf } from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
 
 const MobileNav = () => {
@@ -8,6 +8,7 @@ const MobileNav = () => {
     { to: "/foyer", icon: Users, label: "Foyer fiscal" },
     { to: "/donations", icon: HandCoins, label: "Dons" },
     { to: "/services", icon: HandPlatter, label: "Services" },
+    { to: "/energie", icon: Leaf, label: "Énergie" },
     { to: "/scolarite", icon: GraduationCap, label: "Scolarité" },
   ];
 

--- a/src/pages/Energy.tsx
+++ b/src/pages/Energy.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import Header from "@/components/Header";
+import AddEnergyForm from "@/components/AddEnergyForm";
+import EnergyList from "@/components/EnergyList";
+import EnergyDashboard from "@/components/EnergyDashboard";
+import { EnergyExpense } from "@/types/EnergyExpense";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+const Energy = () => {
+  const [expenses, setExpenses] = useState<EnergyExpense[]>([]);
+  const currentYear = new Date().getFullYear().toString();
+  const [selectedYear, setSelectedYear] = useState(currentYear);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('pimpots-energy');
+    if (stored) {
+      try {
+        setExpenses(JSON.parse(stored));
+      } catch (e) {
+        console.error('Error loading energy expenses from localStorage:', e);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('pimpots-energy', JSON.stringify(expenses));
+  }, [expenses]);
+
+  const years = Array.from(new Set([...expenses.map(e => e.date.slice(0,4)), currentYear])).sort().reverse();
+
+  const filtered = expenses.filter(e => e.date.startsWith(selectedYear));
+
+  const handleAdd = (exp: EnergyExpense) => setExpenses(prev => [...prev, exp]);
+  const handleDelete = (id: string) => setExpenses(prev => prev.filter(e => e.id !== id));
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <main className="container mx-auto px-4 py-8 pb-24 space-y-8">
+        <div className="text-center py-6">
+          <h2 className="text-3xl font-bold text-foreground mb-2">Transition énergétique</h2>
+          <p className="text-muted-foreground">Suivez vos dépenses (cases 7AR à 7AV)</p>
+        </div>
+
+        <EnergyDashboard expenses={filtered} selectedYear={selectedYear} />
+
+        <div className="flex justify-center">
+          <Select value={selectedYear} onValueChange={setSelectedYear}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Année" />
+            </SelectTrigger>
+            <SelectContent>
+              {years.map(year => (
+                <SelectItem key={year} value={year}>{year}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-2">
+          <AddEnergyForm onAdd={handleAdd} />
+          <EnergyList expenses={filtered} onDelete={handleDelete} />
+        </div>
+
+        <p className="text-sm text-muted-foreground text-center">
+          Reportez les travaux d'isolation en case 7AR et les équipements économes en case 7AV.
+        </p>
+      </main>
+    </div>
+  );
+};
+
+export default Energy;
+

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,6 +6,7 @@ import { Receipt } from "@/types/Receipt";
 import { ServiceExpense } from "@/types/ServiceExpense";
 import { Student } from "@/types/Student";
 import { Household } from "@/types/Household";
+import { EnergyExpense } from "@/types/EnergyExpense";
 import { calculateParts, calculateIncomeTax } from "@/lib/tax";
 import {
   Select,
@@ -15,11 +16,13 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import EnergyDashboard from "@/components/EnergyDashboard";
 
 const Index = () => {
   const [receipts, setReceipts] = useState<Receipt[]>([]);
   const [expenses, setExpenses] = useState<ServiceExpense[]>([]);
   const [students, setStudents] = useState<Student[]>([]);
+  const [energy, setEnergy] = useState<EnergyExpense[]>([]);
   const currentYear = new Date().getFullYear().toString();
   const [selectedYear, setSelectedYear] = useState(currentYear);
   const [household, setHousehold] = useState<Household | null>(null);
@@ -52,6 +55,15 @@ const Index = () => {
       }
     }
 
+    const storedEnergy = localStorage.getItem("pimpots-energy");
+    if (storedEnergy) {
+      try {
+        setEnergy(JSON.parse(storedEnergy));
+      } catch (e) {
+        console.error("Error loading energy from localStorage:", e);
+      }
+    }
+
     const storedHousehold = localStorage.getItem("pimpots-household");
     if (storedHousehold) {
       try {
@@ -67,6 +79,7 @@ const Index = () => {
     new Set([
       ...receipts.map((r) => r.date.slice(0, 4)),
       ...expenses.map((e) => e.date.slice(0, 4)),
+      ...energy.map((e) => e.date.slice(0, 4)),
       currentYear,
     ])
   )
@@ -76,6 +89,7 @@ const Index = () => {
   const filteredReceipts = receipts.filter((r) => r.date.startsWith(selectedYear));
   const filteredExpenses = expenses.filter((e) => e.date.startsWith(selectedYear));
   const filteredStudents = students;
+  const filteredEnergy = energy.filter((e) => e.date.startsWith(selectedYear));
 
   const totalDonations = filteredReceipts.reduce((sum, r) => sum + r.amount, 0);
   const donationReduction = Math.round(totalDonations * 0.66);
@@ -219,6 +233,11 @@ const Index = () => {
         <ServicesDashboard expenses={filteredExpenses} selectedYear={selectedYear} />
         <p className="text-sm text-muted-foreground text-center">
           Reportez les services à domicile en case 7DB, la garde d'enfants hors domicile en case 7DF, et les montants par enfant en cases 7GA à 7GG.
+        </p>
+
+        <EnergyDashboard expenses={filteredEnergy} selectedYear={selectedYear} />
+        <p className="text-sm text-muted-foreground text-center">
+          Reportez les travaux d'isolation en case 7AR et les équipements économes en case 7AV.
         </p>
 
         {filteredStudents.length > 0 && (

--- a/src/types/EnergyExpense.ts
+++ b/src/types/EnergyExpense.ts
@@ -1,0 +1,8 @@
+export interface EnergyExpense {
+  id: string;
+  date: string; // Format YYYY-MM-DD
+  category: 'isolation' | 'equipment';
+  description: string;
+  amount: number;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- add energy transition tracking page with form for isolation or efficient equipment
- show energy expenses in main dashboard
- link energy page in navigation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b58222e3688321a0a2cc42995b94dd