### PR TITLE
fix: emphasize summary headings on overview page

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -16,9 +16,9 @@ const Dashboard = ({ receipts, selectedYear }: DashboardProps) => {
     <div className="space-y-6">
       <div className="text-center py-6">
         <h2 className="text-3xl font-bold text-foreground mb-2">
-          Année {selectedYear}
+          Synthèse des dons 66%
         </h2>
-        <p className="text-muted-foreground">Synthèse des dons 66%</p>
+        <p className="text-muted-foreground">Année {selectedYear}</p>
       </div>
 
       <div className="grid gap-4 md:grid-cols-3">

--- a/src/components/EnergyDashboard.tsx
+++ b/src/components/EnergyDashboard.tsx
@@ -18,8 +18,8 @@ const EnergyDashboard = ({ expenses, selectedYear }: EnergyDashboardProps) => {
   return (
     <div className="space-y-6">
       <div className="text-center py-6">
-        <h2 className="text-3xl font-bold text-foreground mb-2">Année {selectedYear}</h2>
-        <p className="text-muted-foreground">Synthèse transition énergétique</p>
+        <h2 className="text-3xl font-bold text-foreground mb-2">Synthèse transition énergétique</h2>
+        <p className="text-muted-foreground">Année {selectedYear}</p>
       </div>
       <div className="grid gap-4 md:grid-cols-3">
         <Card>

--- a/src/components/ServicesDashboard.tsx
+++ b/src/components/ServicesDashboard.tsx
@@ -30,10 +30,8 @@ const ServicesDashboard = ({ expenses, selectedYear }: ServicesDashboardProps) =
   return (
     <div className="space-y-6">
       <div className="text-center py-6">
-        <h2 className="text-3xl font-bold text-foreground mb-2">
-          Année {selectedYear}
-        </h2>
-        <p className="text-muted-foreground">Synthèse des services à la personne</p>
+        <h2 className="text-3xl font-bold text-foreground mb-2">Synthèse des services à la personne</h2>
+        <p className="text-muted-foreground">Année {selectedYear}</p>
       </div>
 
       <div className="grid gap-4 md:grid-cols-4">


### PR DESCRIPTION
## Summary
- make global overview sections display their summaries as main headings
- show selected year as subtitle for donations, services, and energy sections

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b5b188937483218f95bd73d7d7f7a3