### PR TITLE
feat: add 75% donation tracking

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -5,12 +5,24 @@ import { TrendingUp, Euro, FileText } from "lucide-react";
 interface DashboardProps {
   receipts: ReceiptType[];
   selectedYear: string;
+  /**
+   * Tax reduction rate to display. Defaults to 66%.
+   */
+  taxRate?: number;
+  /**
+   * Optional custom tax reduction calculator.
+   * Useful for special cases like 75% donations with a cap.
+   */
+  computeTaxReduction?: (totalAmount: number) => number;
 }
 
-const Dashboard = ({ receipts, selectedYear }: DashboardProps) => {
+const Dashboard = ({ receipts, selectedYear, taxRate = 0.66, computeTaxReduction }: DashboardProps) => {
 
   const totalAmount = receipts.reduce((sum, receipt) => sum + receipt.amount, 0);
-  const taxReduction = Math.round(totalAmount * 0.66);
+  const taxReduction = Math.round(
+    computeTaxReduction ? computeTaxReduction(totalAmount) : totalAmount * taxRate
+  );
+  const percentage = Math.round(taxRate * 100);
 
   return (
     <div className="space-y-6">
@@ -18,7 +30,7 @@ const Dashboard = ({ receipts, selectedYear }: DashboardProps) => {
         <h2 className="text-3xl font-bold text-foreground mb-2">
           Année {selectedYear}
         </h2>
-        <p className="text-muted-foreground">Synthèse des dons 66%</p>
+        <p className="text-muted-foreground">Synthèse des dons {percentage}%</p>
       </div>
 
       <div className="grid gap-4 md:grid-cols-3">
@@ -56,7 +68,7 @@ const Dashboard = ({ receipts, selectedYear }: DashboardProps) => {
           <CardContent>
             <div className="text-2xl font-bold text-success">{taxReduction.toLocaleString('fr-FR')} €</div>
             <p className="text-xs text-success/80">
-              réduction estimée (66%)
+              réduction estimée ({percentage}%)
             </p>
           </CardContent>
         </Card>

--- a/src/components/OtherDonations.tsx
+++ b/src/components/OtherDonations.tsx
@@ -1,12 +1,198 @@
-import React from "react";
+import { useState, useEffect } from "react";
+import { Receipt as ReceiptType } from "@/types/Receipt";
+import Dashboard from "@/components/Dashboard";
+import AddReceiptForm from "@/components/AddReceiptForm";
+import ReceiptsList from "@/components/ReceiptsList";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
 
-const OtherDonations = () => (
-  <div className="text-center py-6 space-y-2">
-    <h2 className="text-3xl font-bold text-foreground mb-2">Autres dons</h2>
-    <p className="text-muted-foreground">
-      Ajoutez ici les dons spécifiques bénéficiant d'une déduction plus avantageuse.
-    </p>
-  </div>
-);
+const STORAGE_KEY = "pimpots-receipts-75";
+
+const computeTaxReduction = (total: number) => {
+  return Math.min(total, 1000) * 0.75 + Math.max(total - 1000, 0) * 0.66;
+};
+
+const OtherDonations = () => {
+  const [receipts, setReceipts] = useState<ReceiptType[]>([]);
+  const [editingReceipt, setEditingReceipt] = useState<ReceiptType | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+  const currentYear = new Date().getFullYear().toString();
+  const [selectedYear, setSelectedYear] = useState(currentYear);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        setReceipts(JSON.parse(stored));
+      } catch (e) {
+        console.error("Error loading 75% receipts from localStorage", e);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(receipts));
+  }, [receipts]);
+
+  const handleAddReceipt = (r: ReceiptType) => setReceipts(prev => [...prev, r]);
+
+  const handleUpdateReceipt = (updated: ReceiptType) => {
+    setReceipts(prev => prev.map(r => (r.id === updated.id ? updated : r)));
+    setEditingReceipt(null);
+  };
+
+  const handleDeleteReceipt = (id: string) => {
+    setReceipts(prev => prev.filter(r => r.id !== id));
+  };
+
+  const handleUpdateReceiptPhoto = (id: string, photo: string | null) => {
+    setReceipts(prev =>
+      prev.map(r => (r.id === id ? { ...r, photo: photo || undefined } : r))
+    );
+  };
+
+  const years = Array.from(
+    new Set([...receipts.map(r => r.date.slice(0, 4)), currentYear])
+  )
+    .sort()
+    .reverse();
+
+  const filteredReceipts = receipts.filter(r => {
+    const matchesYear = r.date.startsWith(selectedYear);
+    const matchesSearch = r.organism
+      .toLowerCase()
+      .includes(searchTerm.toLowerCase());
+    return matchesYear && matchesSearch;
+  });
+
+  const handleDownloadPDF = () => {
+    if (filteredReceipts.length === 0) {
+      toast({
+        title: "Aucun reçu",
+        description: "Aucun reçu trouvé pour l'année sélectionnée.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const title = `Année ${selectedYear}`;
+    const totalAmount = filteredReceipts.reduce((sum, r) => sum + r.amount, 0);
+    const taxReduction = Math.round(computeTaxReduction(totalAmount));
+
+    const rows = filteredReceipts
+      .map(
+        r =>
+          `<tr><td>${new Date(r.date).toLocaleDateString('fr-FR')}</td><td>${r.organism}</td><td>${r.amount.toLocaleString('fr-FR')} €</td></tr>`
+      )
+      .join("");
+
+    const photosHtml = filteredReceipts
+      .filter(r => r.photo)
+      .map(
+        (r, i) =>
+          `<div class="receipt-photo"><h3>Reçu ${i + 1} - ${r.organism} (${new Date(r.date).toLocaleDateString('fr-FR')})</h3><img src="${r.photo}" alt="Reçu ${i + 1}" /></div>`
+      )
+      .join("");
+
+    const photosSection = photosHtml
+      ? `<div class="page-break"></div><h2>Photos des reçus fiscaux</h2>${photosHtml}`
+      : "";
+
+    const printWindow = window.open("", "_blank");
+    if (!printWindow) return;
+    printWindow.document.write(`<!DOCTYPE html><html><head><title>Reçus fiscaux ${title}</title><style>
+        body{font-family:Arial,sans-serif;padding:20px;}
+        table{width:100%;border-collapse:collapse;margin-top:20px;}
+        th,td{border:1px solid #000;padding:8px;text-align:left;}
+        h1{margin-bottom:10px;}
+        h2{margin-top:40px;}
+        img{max-width:100%;height:auto;margin-top:8px;}
+        .receipt-photo{margin-bottom:20px;}
+        @media print { .page-break { page-break-before: always; } }
+      </style></head><body>
+        <h1>Reçus fiscaux ${title}</h1>
+        <p><strong>Montant total des dons :</strong> ${totalAmount.toLocaleString('fr-FR')} €</p>
+        <p>Le montant total des dons de l'année est à saisir dans la case 7UD de la déclaration d'impôts.</p>
+        <p><strong>Réduction fiscale (75%*) :</strong> ${taxReduction.toLocaleString('fr-FR')} €</p>
+        <p>*75% dans la limite de 1 000 €, au-delà 66%.</p>
+        <p>Document justificatif à présenter à l'administration fiscale en cas de contrôle.</p>
+        <table><thead><tr><th>Date</th><th>Organisme</th><th>Montant</th></tr></thead><tbody>${rows}</tbody></table>
+        ${photosSection}
+      </body></html>`);
+    printWindow.document.close();
+    printWindow.focus();
+    printWindow.print();
+  };
+
+  return (
+    <div className="space-y-8">
+      <div className="text-center py-6">
+        <h2 className="text-3xl font-bold text-foreground mb-2">Dons 75%</h2>
+        <p className="text-muted-foreground">Organismes d’aide aux personnes en difficulté</p>
+      </div>
+      <Dashboard
+        receipts={filteredReceipts}
+        selectedYear={selectedYear}
+        taxRate={0.75}
+        computeTaxReduction={computeTaxReduction}
+      />
+
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <Input
+          placeholder="Rechercher un organisme"
+          value={searchTerm}
+          onChange={e => setSearchTerm(e.target.value)}
+          className="max-w-md"
+        />
+        <div className="flex gap-2">
+          <Select value={selectedYear} onValueChange={setSelectedYear}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Année" />
+            </SelectTrigger>
+            <SelectContent>
+              {years.map(year => (
+                <SelectItem key={year} value={year}>
+                  {year}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button onClick={handleDownloadPDF}>Exporter PDF</Button>
+        </div>
+      </div>
+
+      <div className="grid gap-8 lg:grid-cols-2">
+        <div>
+          <AddReceiptForm
+            onAddReceipt={handleAddReceipt}
+            initialData={editingReceipt || undefined}
+            onUpdateReceipt={handleUpdateReceipt}
+            onCancelEdit={() => setEditingReceipt(null)}
+          />
+        </div>
+
+        <div>
+          <ReceiptsList
+            receipts={filteredReceipts}
+            onDeleteReceipt={handleDeleteReceipt}
+            onEditReceipt={receipt => setEditingReceipt(receipt)}
+            onUpdatePhoto={handleUpdateReceiptPhoto}
+            taxRate={0.75}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
 
 export default OtherDonations;
+

--- a/src/components/ReceiptsList.tsx
+++ b/src/components/ReceiptsList.tsx
@@ -10,9 +10,13 @@ interface ReceiptsListProps {
   onDeleteReceipt: (id: string) => void;
   onEditReceipt: (receipt: ReceiptType) => void;
   onUpdatePhoto: (id: string, photo: string | null) => void;
+  /**
+   * Tax reduction rate applied to each receipt. Defaults to 66%.
+   */
+  taxRate?: number;
 }
 
-const ReceiptsList = ({ receipts, onDeleteReceipt, onEditReceipt, onUpdatePhoto }: ReceiptsListProps) => {
+const ReceiptsList = ({ receipts, onDeleteReceipt, onEditReceipt, onUpdatePhoto, taxRate = 0.66 }: ReceiptsListProps) => {
   const sortedReceipts = [...receipts].sort((a, b) =>
     new Date(b.date).getTime() - new Date(a.date).getTime()
   );
@@ -145,7 +149,7 @@ const ReceiptsList = ({ receipts, onDeleteReceipt, onEditReceipt, onUpdatePhoto 
                   <span className="font-semibold text-lg">{receipt.amount.toLocaleString('fr-FR')} €</span>
                 </div>
                 <Badge variant="secondary" className="text-xs bg-success-light text-success sm:ml-auto">
-                  -{Math.round(receipt.amount * 0.66)} € d'impôt
+                  -{Math.round(receipt.amount * taxRate)} € d'impôt
                 </Badge>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add interface for 75% deductible donations
- generalize dashboard and receipts list to handle variable tax rates

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5b1e376a883219798ab0dae63e0bf