### PR TITLE
Uniformise les sous-titres et met à jour le slogan

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,6 @@ import { Link, useLocation } from "react-router-dom";
 
 const Header = () => {
   const location = useLocation();
-  const currentYear = new Date().getFullYear();
   return (
     <header className="bg-card border-b border-border">
       <div className="container mx-auto px-4 py-6">
@@ -12,7 +11,11 @@ const Header = () => {
             <img src={logo} alt="Logo Pimpôts" className="h-12 w-12" />
             <div>
               <h1 className="text-2xl font-bold text-foreground">Pimpôts</h1>
-              <p className="text-sm text-muted-foreground">Année {currentYear}</p>
+              <p className="text-sm text-muted-foreground">
+                Faciliter le suivi tout au long de l'année...
+                <br />
+                Pour pimper votre déclaration d'impôts
+              </p>
             </div>
           </Link>
           <nav className="hidden gap-4 sm:flex">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -357,9 +357,11 @@ const Index = () => {
                     </li>
                   ))}
                 </ul>
-                <p className="text-sm text-muted-foreground">Déduction d'impôt</p>
               </CardContent>
             </Card>
+            <p className="text-sm text-muted-foreground text-center">
+              Déduction d'impôt
+            </p>
             <p className="text-sm text-muted-foreground text-center">
               Reportez les montants par enfant dans les cases 7EA, 7EC et 7EF.
             </p>


### PR DESCRIPTION
## Summary
- Harmonise le sous-titre de la section scolarité dans l'onglet Aperçu
- Remplace "Année 2025" par le nouveau slogan dans l'en-tête

## Testing
- `npm test` (échoue : Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b89a6c420c83218dc4a63202eb99cc