### PR TITLE
Align donations tab and 75% deduction math

### DIFF
--- a/src/components/OtherDonations.tsx
+++ b/src/components/OtherDonations.tsx
@@ -80,6 +80,23 @@ const OtherDonations = () => {
     return matchesYear && matchesSearch;
   });
 
+  const calculateTaxReductions = (list: ReceiptType[]) => {
+    let remaining = 1000;
+    const reductions: Record<string, number> = {};
+    const chronological = [...list].sort(
+      (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+    );
+    chronological.forEach((r) => {
+      const amount75 = Math.min(r.amount, remaining);
+      const amount66 = r.amount - amount75;
+      reductions[r.id] = Math.round(amount75 * 0.75 + amount66 * 0.66);
+      remaining -= amount75;
+    });
+    return reductions;
+  };
+
+  const taxReductions = calculateTaxReductions(filteredReceipts);
+
   const handleDownloadPDF = () => {
     if (filteredReceipts.length === 0) {
       toast({
@@ -189,6 +206,7 @@ const OtherDonations = () => {
             onEditReceipt={(receipt) => setEditingReceipt(receipt)}
             onUpdatePhoto={handleUpdateReceiptPhoto}
             taxRate={0.75}
+            taxReductions={taxReductions}
           />
         </div>
       </div>

--- a/src/components/ReceiptsList.tsx
+++ b/src/components/ReceiptsList.tsx
@@ -11,11 +11,12 @@ interface ReceiptsListProps {
   onEditReceipt: (receipt: ReceiptType) => void;
   onUpdatePhoto: (id: string, photo: string | null) => void;
   taxRate?: number;
+  taxReductions?: Record<string, number>;
 }
 
-const ReceiptsList = ({ receipts, onDeleteReceipt, onEditReceipt, onUpdatePhoto, taxRate = 0.66 }: ReceiptsListProps) => {
-  const sortedReceipts = [...receipts].sort((a, b) =>
-    new Date(b.date).getTime() - new Date(a.date).getTime()
+const ReceiptsList = ({ receipts, onDeleteReceipt, onEditReceipt, onUpdatePhoto, taxRate = 0.66, taxReductions }: ReceiptsListProps) => {
+  const sortedReceipts = [...receipts].sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
   );
   const fileInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
 
@@ -145,8 +146,16 @@ const ReceiptsList = ({ receipts, onDeleteReceipt, onEditReceipt, onUpdatePhoto,
                   <Euro className="h-4 w-4 text-muted-foreground" />
                   <span className="font-semibold text-lg">{receipt.amount.toLocaleString('fr-FR')} €</span>
                 </div>
-                <Badge variant="secondary" className="text-xs bg-success-light text-success sm:ml-auto">
-                  -{Math.round(receipt.amount * taxRate)} € d'impôt
+                <Badge
+                  variant="secondary"
+                  className="text-xs bg-success-light text-success sm:ml-auto"
+                >
+                  -{
+                    (taxReductions && receipt.id in taxReductions
+                      ? taxReductions[receipt.id]
+                      : Math.round(receipt.amount * taxRate)
+                    ).toLocaleString('fr-FR')
+                  } € d'impôt
                 </Badge>
               </div>
             </div>

--- a/src/pages/Donations.tsx
+++ b/src/pages/Donations.tsx
@@ -10,7 +10,7 @@ const Donations = () => (
       <Tabs defaultValue="66" className="space-y-8">
         <TabsList className="grid w-full max-w-md grid-cols-2 mx-auto">
           <TabsTrigger value="66">Dons 66%</TabsTrigger>
-          <TabsTrigger value="other">Autres dons</TabsTrigger>
+          <TabsTrigger value="other">Dons 75%</TabsTrigger>
         </TabsList>
         <TabsContent value="66">
           <Donations66 />


### PR DESCRIPTION
## Summary
- Rename "Autres dons" tab to "Dons 75%"
- Calculate per-receipt tax savings with 75%/66% thresholds so totals match the dashboard

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b989e96c6c8321ab2aab037eb35f4c