### PR TITLE
Add title to schooling summary card

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -346,6 +346,11 @@ const Index = () => {
               <p className="text-muted-foreground">Année {selectedYear}</p>
             </div>
             <Card className="max-w-xl mx-auto">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium">
+                  Montant total
+                </CardTitle>
+              </CardHeader>
               <CardContent className="space-y-2">
                 <div className="text-2xl font-bold">
                   {schoolingTotals.total.toLocaleString("fr-FR")} €


### PR DESCRIPTION
## Summary
- add an internal "Montant total" heading to the schooling summary card for consistent styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b993855e008321b006ce10b504b0a4