### PR TITLE
feat: update donation caps to 2000 and apply income limit

### DIFF
--- a/src/components/OtherDashboard.tsx
+++ b/src/components/OtherDashboard.tsx
@@ -9,8 +9,8 @@ interface DashboardProps {
 
 const OtherDashboard = ({ receipts, selectedYear }: DashboardProps) => {
   const totalAmount = receipts.reduce((sum, receipt) => sum + receipt.amount, 0);
-  const base75 = Math.min(totalAmount, 1000);
-  const base66 = Math.max(totalAmount - 1000, 0);
+  const base75 = Math.min(totalAmount, 2000);
+  const base66 = Math.max(totalAmount - 2000, 0);
   const taxReduction = Math.round(base75 * 0.75 + base66 * 0.66);
 
   return (
@@ -59,7 +59,7 @@ const OtherDashboard = ({ receipts, selectedYear }: DashboardProps) => {
           <CardContent>
             <div className="text-2xl font-bold text-success">{taxReduction.toLocaleString('fr-FR')} €</div>
             <p className="text-xs text-success/80">
-              réduction estimée (75% jusqu'à 1 000 €)
+              réduction estimée (75% jusqu'à 2 000 €)
             </p>
           </CardContent>
         </Card>

--- a/src/components/OtherDonations.tsx
+++ b/src/components/OtherDonations.tsx
@@ -81,7 +81,7 @@ const OtherDonations = () => {
   });
 
   const calculateTaxReductions = (list: ReceiptType[]) => {
-    let remaining = 1000;
+    let remaining = 2000;
     const reductions: Record<string, number> = {};
     const chronological = [...list].sort(
       (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
@@ -109,8 +109,8 @@ const OtherDonations = () => {
 
     const title = `Année ${selectedYear}`;
     const totalAmount = filteredReceipts.reduce((sum, r) => sum + r.amount, 0);
-    const base75 = Math.min(totalAmount, 1000);
-    const base66 = Math.max(totalAmount - 1000, 0);
+    const base75 = Math.min(totalAmount, 2000);
+    const base66 = Math.max(totalAmount - 2000, 0);
     const taxReduction = Math.round(base75 * 0.75 + base66 * 0.66);
 
     const rows = filteredReceipts
@@ -147,7 +147,7 @@ const OtherDonations = () => {
         <h1>Reçus fiscaux ${title}</h1>
         <p><strong>Montant total des dons :</strong> ${totalAmount.toLocaleString('fr-FR')} €</p>
         <p>Le montant total des dons de l'année est à saisir dans la case 7UD de la déclaration d'impôts.</p>
-        <p><strong>Réduction fiscale (75% jusqu'à 1 000 €) :</strong> ${taxReduction.toLocaleString('fr-FR')} €</p>
+        <p><strong>Réduction fiscale (75% jusqu'à 2 000 €) :</strong> ${taxReduction.toLocaleString('fr-FR')} €</p>
         <p>Document justificatif à présenter à l'administration fiscale en cas de contrôle.</p>
         <table><thead><tr><th>Date</th><th>Organisme</th><th>Montant</th></tr></thead><tbody>${rows}</tbody></table>
         ${photosSection}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -113,9 +113,15 @@ const Index = () => {
 
   const totalDonations66 = filteredReceipts.reduce((sum, r) => sum + r.amount, 0);
   const totalDonations75 = filteredOtherReceipts.reduce((sum, r) => sum + r.amount, 0);
-  const base75 = Math.min(totalDonations75, 1000);
-  const excess75 = Math.max(totalDonations75 - 1000, 0);
-  const total7UF = totalDonations66 + excess75;
+  const base75 = Math.min(totalDonations75, 2000);
+  const excess75 = Math.max(totalDonations75 - 2000, 0);
+  const totalIncome = household
+    ? household.members.reduce((s, m) => s + (m.salary || 0), 0) +
+      (household.otherIncome || 0)
+    : 0;
+  const limit20 = totalIncome * 0.2;
+  const total7UF = Math.min(totalDonations66 + excess75, limit20);
+  const donationCarryForward = Math.max(totalDonations66 + excess75 - limit20, 0);
   const total7UD = base75;
   const donationReduction = Math.round(total7UF * 0.66 + total7UD * 0.75);
   const schoolingTotals = filteredStudents.reduce(
@@ -158,9 +164,6 @@ const Index = () => {
             1,
             household.members.filter((m) => m.name || m.salary).length
           );
-    const totalIncome =
-      household.members.reduce((s, m) => s + (m.salary || 0), 0) +
-      (household.otherIncome || 0);
     const parts = calculateParts(adults, household.children);
     incomeTax = calculateIncomeTax(totalIncome, parts);
     donationReductionApplied = Math.min(donationReduction, incomeTax);


### PR DESCRIPTION
## Summary
- raise 75% donation base to 2000
- enforce 20% taxable income limit for donation deductions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b98f4618588321a44cf04845138c04