### PR TITLE
feat: add public home page with onboarding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import MobileNav from "./components/MobileNav";
 import ProtectedRoute from "./components/ProtectedRoute";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
+import Home from "./pages/Home";
 
 const queryClient = new QueryClient();
 
@@ -24,15 +25,16 @@ const App = () => (
       <Sonner />
       <BrowserRouter>
         <Routes>
+          <Route path="/" element={<Home />} />
           <Route path="/connexion" element={<Login />} />
           <Route path="/inscription" element={<Register />} />
           <Route element={<ProtectedRoute />}>
-            <Route path="/" element={<Index />} />
-            <Route path="/foyer" element={<HouseholdPage />} />
-            <Route path="/donations" element={<Donations />} />
-            <Route path="/services" element={<Services />} />
-            <Route path="/energie" element={<Energy />} />
-            <Route path="/scolarite" element={<Schooling />} />
+            <Route path="/app" element={<Index />} />
+            <Route path="/app/foyer" element={<HouseholdPage />} />
+            <Route path="/app/donations" element={<Donations />} />
+            <Route path="/app/services" element={<Services />} />
+            <Route path="/app/energie" element={<Energy />} />
+            <Route path="/app/scolarite" element={<Schooling />} />
           </Route>
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,11 +9,24 @@ const Header = () => {
   const { user, signOut } = useAuth();
   const displayName = user?.displayName?.trim();
   const subtitle = displayName || user?.email || "";
+
+  const navItems = [
+    { to: "/app", label: "Aperçu" },
+    { to: "/app/foyer", label: "Foyer fiscal" },
+    { to: "/app/donations", label: "Dons" },
+    { to: "/app/services", label: "Services à la personne" },
+    { to: "/app/energie", label: "Transition énergétique" },
+    { to: "/app/scolarite", label: "Scolarité" },
+  ];
+
+  const isActive = (path: string) =>
+    location.pathname === path || location.pathname.startsWith(`${path}/`);
+
   return (
     <header className="bg-card border-b border-border">
       <div className="container mx-auto px-4 py-6">
         <div className="flex items-center justify-between gap-3">
-          <Link to="/" className="flex items-center gap-3">
+          <Link to="/app" className="flex items-center gap-3">
             <img src={logo} alt="Logo Pimpôts" className="h-12 w-12" />
             <div>
               <h1 className="text-2xl font-bold text-foreground">Pimpôts</h1>
@@ -25,46 +38,19 @@ const Header = () => {
             </div>
           </Link>
           <nav className="hidden items-center gap-4 sm:flex">
-            <Link
-              to="/"
-              className={`text-sm font-medium hover:underline ${location.pathname === '/' ? 'text-primary' : 'text-foreground'}`}
-            >
-              Aperçu
-            </Link>
-            <Link
-              to="/foyer"
-              className={`text-sm font-medium hover:underline ${location.pathname === '/foyer' ? 'text-primary' : 'text-foreground'}`}
-            >
-              Foyer fiscal
-            </Link>
-            <Link
-              to="/donations"
-              className={`text-sm font-medium hover:underline ${location.pathname === '/donations' ? 'text-primary' : 'text-foreground'}`}
-            >
-              Dons
-            </Link>
-            <Link
-              to="/services"
-              className={`text-sm font-medium hover:underline ${location.pathname === '/services' ? 'text-primary' : 'text-foreground'}`}
-            >
-              Services à la personne
-            </Link>
-            <Link
-              to="/energie"
-              className={`text-sm font-medium hover:underline ${location.pathname === '/energie' ? 'text-primary' : 'text-foreground'}`}
-            >
-              Transition énergétique
-            </Link>
-            <Link
-              to="/scolarite"
-              className={`text-sm font-medium hover:underline ${location.pathname === '/scolarite' ? 'text-primary' : 'text-foreground'}`}
-            >
-              Scolarité
-            </Link>
+            {navItems.map(({ to, label }) => (
+              <Link
+                key={to}
+                to={to}
+                className={`text-sm font-medium hover:underline ${
+                  isActive(to) ? "text-primary" : "text-foreground"
+                }`}
+              >
+                {label}
+              </Link>
+            ))}
             <div className="ml-4 flex items-center gap-3">
-              {subtitle ? (
-                <span className="text-sm text-muted-foreground">{subtitle}</span>
-              ) : null}
+              {subtitle ? <span className="text-sm text-muted-foreground">{subtitle}</span> : null}
               <Button
                 variant="outline"
                 size="sm"

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -6,17 +6,21 @@ const MobileNav = () => {
   const location = useLocation();
   const { user } = useAuth();
 
-  if (!user) {
+  if (!user || !location.pathname.startsWith("/app")) {
     return null;
   }
+
   const items = [
-    { to: "/", icon: Home, label: "Aperçu" },
-    { to: "/foyer", icon: Users, label: "Foyer fiscal" },
-    { to: "/donations", icon: HandCoins, label: "Dons" },
-    { to: "/services", icon: HandPlatter, label: "Services" },
-    { to: "/energie", icon: Leaf, label: "Énergie" },
-    { to: "/scolarite", icon: GraduationCap, label: "Scolarité" },
+    { to: "/app", icon: Home, label: "Aperçu" },
+    { to: "/app/foyer", icon: Users, label: "Foyer fiscal" },
+    { to: "/app/donations", icon: HandCoins, label: "Dons" },
+    { to: "/app/services", icon: HandPlatter, label: "Services" },
+    { to: "/app/energie", icon: Leaf, label: "Énergie" },
+    { to: "/app/scolarite", icon: GraduationCap, label: "Scolarité" },
   ];
+
+  const isActive = (path: string) =>
+    location.pathname === path || location.pathname.startsWith(`${path}/`);
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 flex justify-around border-t border-border bg-card py-2 sm:hidden">
@@ -25,7 +29,7 @@ const MobileNav = () => {
           key={to}
           to={to}
           className={`flex flex-col items-center ${
-            location.pathname === to ? "text-primary" : "text-muted-foreground"
+            isActive(to) ? "text-primary" : "text-muted-foreground"
           }`}
         >
           <Icon className="h-6 w-6" />

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -1,0 +1,42 @@
+import { UserProfile } from "@/types/UserData";
+
+export const ONBOARDING_PROFILE_STORAGE_KEY = "pimpots-onboarding-profile" as const;
+
+export type OnboardingProfile = Pick<UserProfile, "firstName" | "lastName" | "email">;
+
+const safeParse = (value: string | null): OnboardingProfile | null => {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as Partial<OnboardingProfile>;
+    if (
+      typeof parsed?.firstName === "string" &&
+      typeof parsed?.lastName === "string" &&
+      typeof parsed?.email === "string"
+    ) {
+      return {
+        firstName: parsed.firstName,
+        lastName: parsed.lastName,
+        email: parsed.email,
+      };
+    }
+    return null;
+  } catch (error) {
+    console.error("Failed to parse onboarding profile", error);
+    return null;
+  }
+};
+
+export const readOnboardingProfile = (): OnboardingProfile | null => {
+  if (typeof window === "undefined") return null;
+  return safeParse(localStorage.getItem(ONBOARDING_PROFILE_STORAGE_KEY));
+};
+
+export const saveOnboardingProfile = async (profile: OnboardingProfile) => {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(ONBOARDING_PROFILE_STORAGE_KEY, JSON.stringify(profile));
+};
+
+export const clearOnboardingProfile = () => {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(ONBOARDING_PROFILE_STORAGE_KEY);
+};

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,442 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import {
+  ArrowRight,
+  CalendarCheck,
+  CheckCircle2,
+  LineChart,
+  ShieldCheck,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  OnboardingProfile,
+  readOnboardingProfile,
+  saveOnboardingProfile,
+} from "@/lib/onboarding";
+import { LOCAL_STORAGE_KEYS } from "@/lib/user-data";
+import { Household, MaritalStatus } from "@/types/Household";
+import { calculateIncomeTax, calculateParts } from "@/lib/tax";
+
+const defaultHousehold: Household = {
+  status: "marie",
+  members: [
+    { name: "", salary: 0 },
+    { name: "", salary: 0 },
+  ],
+  children: 0,
+  otherIncome: 0,
+};
+
+const heroHighlights = [
+  {
+    icon: CalendarCheck,
+    title: "Suivi annuel",
+    description: "Centralisez vos dons, dépenses et crédits d'impôt toute l'année.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Données sécurisées",
+    description: "Vos informations sont prêtes à être stockées dans Firebase.",
+  },
+  {
+    icon: LineChart,
+    title: "Projection instantanée",
+    description: "Visualisez l'impact de votre foyer fiscal en temps réel.",
+  },
+];
+
+const parseStoredHousehold = (value: string | null): Household => {
+  if (!value) return defaultHousehold;
+  try {
+    const parsed = JSON.parse(value) as Partial<Household>;
+    const members = Array.isArray(parsed.members)
+      ? parsed.members.map((member) => ({
+          name: typeof member?.name === "string" ? member.name : "",
+          salary: typeof member?.salary === "number" ? member.salary : 0,
+        }))
+      : defaultHousehold.members;
+    while (members.length < 2) {
+      members.push({ name: "", salary: 0 });
+    }
+    return {
+      status: (parsed.status as MaritalStatus) ?? defaultHousehold.status,
+      members,
+      children: typeof parsed.children === "number" ? parsed.children : defaultHousehold.children,
+      otherIncome:
+        typeof parsed.otherIncome === "number" ? parsed.otherIncome : defaultHousehold.otherIncome,
+    } satisfies Household;
+  } catch (error) {
+    console.error("Failed to parse stored household", error);
+    return defaultHousehold;
+  }
+};
+
+const Home = () => {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const { user } = useAuth();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [accountForm, setAccountForm] = useState<OnboardingProfile>(() => {
+    const stored = readOnboardingProfile();
+    return (
+      stored ?? {
+        firstName: "",
+        lastName: "",
+        email: "",
+      }
+    );
+  });
+  const [household, setHousehold] = useState<Household>(() => {
+    if (typeof window === "undefined") {
+      return defaultHousehold;
+    }
+    return parseStoredHousehold(localStorage.getItem(LOCAL_STORAGE_KEYS.household));
+  });
+
+  useEffect(() => {
+    if (!user && typeof window !== "undefined") {
+      localStorage.setItem(LOCAL_STORAGE_KEYS.household, JSON.stringify(household));
+    }
+  }, [household, user]);
+
+  const adults = useMemo(() => {
+    const declaredAdults = household.members.filter((member) => member.name || member.salary).length;
+    if (household.status === "concubinage") {
+      return 1;
+    }
+    return Math.max(1, declaredAdults || household.members.length);
+  }, [household.members, household.status]);
+
+  const parts = useMemo(() => calculateParts(adults, household.children), [adults, household.children]);
+  const totalIncome = useMemo(
+    () =>
+      household.members.reduce((acc, member) => acc + (member.salary || 0), 0) +
+      (household.otherIncome || 0),
+    [household.members, household.otherIncome]
+  );
+  const estimatedTax = useMemo(() => {
+    if (!totalIncome || !parts) return 0;
+    return Math.round(calculateIncomeTax(totalIncome, parts));
+  }, [totalIncome, parts]);
+
+  const handleAccountSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (user) {
+      navigate("/app");
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const payload: OnboardingProfile = {
+        firstName: accountForm.firstName.trim(),
+        lastName: accountForm.lastName.trim(),
+        email: accountForm.email.trim(),
+      };
+      await saveOnboardingProfile(payload);
+      toast({
+        title: "Presque terminé !",
+        description: "Choisissez un mot de passe pour finaliser votre inscription.",
+      });
+      navigate("/inscription", { state: { prefill: payload } });
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: "Inscription impossible",
+        description: "Une erreur est survenue. Veuillez réessayer.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleMemberChange = (index: number, field: "name" | "salary", value: string) => {
+    setHousehold((prev) => {
+      const members = [...prev.members];
+      const current = members[index] ?? { name: "", salary: 0 };
+      const nextMember = {
+        ...current,
+        [field]: field === "salary" ? Number(value) || 0 : value,
+      };
+      members[index] = nextMember;
+      return { ...prev, members };
+    });
+  };
+
+  const handleStatusChange = (value: string) => {
+    setHousehold((prev) => ({ ...prev, status: value as MaritalStatus }));
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="border-b border-border bg-card/60 backdrop-blur">
+        <div className="container mx-auto flex items-center justify-between px-4 py-4">
+          <Link to="/" className="text-lg font-semibold text-primary">
+            Pimpôts
+          </Link>
+          <div className="flex items-center gap-3">
+            {user ? (
+              <Button variant="ghost" asChild>
+                <Link to="/app">Accéder à mon espace</Link>
+              </Button>
+            ) : (
+              <>
+                <Button variant="ghost" asChild>
+                  <Link to="/connexion">Se connecter</Link>
+                </Button>
+                <Button asChild>
+                  <Link to="#ouvrir-compte">Ouvrir un compte</Link>
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <main className="space-y-20 pb-20">
+        <section className="bg-muted/30">
+          <div className="container mx-auto grid gap-12 px-4 py-16 lg:grid-cols-[1.2fr_1fr]">
+            <div className="space-y-6">
+              <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-1 text-sm font-medium text-primary">
+                <ShieldCheck className="h-4 w-4" />
+                Déclarez vos avantages fiscaux sans stress
+              </div>
+              <h1 className="text-3xl font-bold leading-tight text-foreground sm:text-4xl lg:text-5xl">
+                Le compagnon qui simplifie votre déclaration d'impôts
+              </h1>
+              <p className="max-w-2xl text-lg text-muted-foreground">
+                Enregistrez vos dons, vos services à la personne et vos dépenses énergétiques au fil de l'année.
+                Lorsque vous êtes prêt, connectez votre compte Firebase pour conserver toutes vos informations.
+              </p>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {heroHighlights.map(({ icon: Icon, title, description }) => (
+                  <div key={title} className="flex items-start gap-3">
+                    <div className="mt-1 rounded-full bg-primary/10 p-2 text-primary">
+                      <Icon className="h-5 w-5" />
+                    </div>
+                    <div>
+                      <h3 className="text-base font-semibold text-foreground">{title}</h3>
+                      <p className="text-sm text-muted-foreground">{description}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <div className="flex flex-wrap gap-3">
+                <Button asChild size="lg">
+                  <Link to="#ouvrir-compte" className="flex items-center gap-2">
+                    Je crée mon compte
+                    <ArrowRight className="h-4 w-4" />
+                  </Link>
+                </Button>
+                <Button variant="outline" size="lg" asChild>
+                  <Link to="/connexion">J'ai déjà un compte</Link>
+                </Button>
+              </div>
+            </div>
+
+            <Card id="ouvrir-compte" className="shadow-lg">
+              <CardHeader>
+                <CardTitle>Ouvrir un compte</CardTitle>
+                <CardDescription>
+                  Renseignez vos informations pour finaliser votre inscription et connecter votre foyer à Firebase.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <form className="space-y-4" onSubmit={handleAccountSubmit}>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label htmlFor="firstName">Prénom</Label>
+                      <Input
+                        id="firstName"
+                        value={accountForm.firstName}
+                        onChange={(event) =>
+                          setAccountForm((prev) => ({ ...prev, firstName: event.target.value }))
+                        }
+                        autoComplete="given-name"
+                        required
+                        disabled={Boolean(user)}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="lastName">Nom</Label>
+                      <Input
+                        id="lastName"
+                        value={accountForm.lastName}
+                        onChange={(event) =>
+                          setAccountForm((prev) => ({ ...prev, lastName: event.target.value }))
+                        }
+                        autoComplete="family-name"
+                        required
+                        disabled={Boolean(user)}
+                      />
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="email">Adresse mail</Label>
+                    <Input
+                      id="email"
+                      type="email"
+                      value={accountForm.email}
+                      onChange={(event) =>
+                        setAccountForm((prev) => ({ ...prev, email: event.target.value }))
+                      }
+                      autoComplete="email"
+                      required
+                      disabled={Boolean(user)}
+                    />
+                  </div>
+                  <Button type="submit" className="w-full" disabled={isSubmitting || Boolean(user)}>
+                    {user ? "Vous êtes déjà connecté" : "Continuer"}
+                  </Button>
+                  <p className="text-sm text-muted-foreground">
+                    Vous serez redirigé pour choisir un mot de passe sécurisé avant que vos données ne soient synchronisées.
+                  </p>
+                </form>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+
+        <section className="container mx-auto px-4">
+          <div className="grid gap-8 lg:grid-cols-[1.2fr_1fr]">
+            <Card>
+              <CardHeader>
+                <CardTitle>Simuler mon foyer fiscal</CardTitle>
+                <CardDescription>
+                  Ajustez les informations ci-dessous pour visualiser immédiatement votre situation. Les données ne sont
+                  enregistrées que si vous n'êtes pas connecté.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid gap-4 md:grid-cols-2">
+                  {household.members.map((member, index) => (
+                    <div key={index} className="space-y-2">
+                      <Label htmlFor={`member-${index}`}>{`Personne ${index + 1}`}</Label>
+                      <Input
+                        id={`member-${index}`}
+                        placeholder="Nom"
+                        value={member.name}
+                        onChange={(event) => handleMemberChange(index, "name", event.target.value)}
+                      />
+                      <Input
+                        type="number"
+                        inputMode="numeric"
+                        placeholder="Revenu net annuel (€)"
+                        value={member.salary || ""}
+                        onChange={(event) => handleMemberChange(index, "salary", event.target.value)}
+                      />
+                    </div>
+                  ))}
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="other-income">Autres revenus annuels (€)</Label>
+                  <Input
+                    id="other-income"
+                    type="number"
+                    inputMode="numeric"
+                    value={household.otherIncome || ""}
+                    onChange={(event) =>
+                      setHousehold((prev) => ({
+                        ...prev,
+                        otherIncome: Number(event.target.value) || 0,
+                      }))
+                    }
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="children">Nombre d'enfants à charge</Label>
+                  <Input
+                    id="children"
+                    type="number"
+                    inputMode="numeric"
+                    value={household.children}
+                    onChange={(event) =>
+                      setHousehold((prev) => ({
+                        ...prev,
+                        children: Math.max(0, Number(event.target.value) || 0),
+                      }))
+                    }
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Situation familiale</Label>
+                  <RadioGroup value={household.status} onValueChange={handleStatusChange} className="flex gap-4">
+                    <div className="flex items-center space-x-2">
+                      <RadioGroupItem value="marie" id="marie" />
+                      <Label htmlFor="marie">Marié</Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <RadioGroupItem value="pacse" id="pacse" />
+                      <Label htmlFor="pacse">Pacsé</Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <RadioGroupItem value="concubinage" id="concubinage" />
+                      <Label htmlFor="concubinage">Concubinage</Label>
+                    </div>
+                  </RadioGroup>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="border-primary/50 bg-primary/5">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-primary">
+                  <CheckCircle2 className="h-5 w-5" />
+                  Résumé instantané
+                </CardTitle>
+                <CardDescription>
+                  Ces calculs sont fournis à titre indicatif et vous permettent d'évaluer l'intérêt d'un suivi continu.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid gap-4">
+                  <div className="flex items-center justify-between rounded-md bg-background px-4 py-3">
+                    <span className="text-sm text-muted-foreground">Revenu annuel total</span>
+                    <span className="text-lg font-semibold text-foreground">
+                      {totalIncome.toLocaleString("fr-FR")}{" €"}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between rounded-md bg-background px-4 py-3">
+                    <span className="text-sm text-muted-foreground">Nombre de parts fiscales</span>
+                    <span className="text-lg font-semibold text-foreground">{parts.toFixed(2)}</span>
+                  </div>
+                  <div className="flex items-center justify-between rounded-md bg-background px-4 py-3">
+                    <span className="text-sm text-muted-foreground">Impôt estimé</span>
+                    <span className="text-lg font-semibold text-foreground">
+                      {estimatedTax.toLocaleString("fr-FR")}{" €"}
+                    </span>
+                  </div>
+                </div>
+                <div className="space-y-2 rounded-md bg-background px-4 py-3 text-sm text-muted-foreground">
+                  <p>
+                    {user
+                      ? "Les informations saisies ici ne sont pas enregistrées pendant que vous êtes connecté."
+                      : "Ces informations seront conservées sur votre appareil jusqu'à la création de votre compte."}
+                  </p>
+                  <p>
+                    Connectez-vous pour enregistrer définitivement vos données et suivre vos crédits d'impôt au fil des
+                    mois.
+                  </p>
+                </div>
+                <Button asChild>
+                  <Link to={user ? "/app" : "/connexion"} className="flex items-center gap-2">
+                    {user ? "Accéder à mon tableau de bord" : "Je poursuis mon inscription"}
+                    <ArrowRight className="h-4 w-4" />
+                  </Link>
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default Home;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -16,7 +16,7 @@ const Login = () => {
   const [formData, setFormData] = useState({ email: "", password: "" });
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const from = (location.state as { from?: { pathname?: string } } | undefined)?.from?.pathname ?? "/";
+  const from = (location.state as { from?: { pathname?: string } } | undefined)?.from?.pathname ?? "/app";
 
   useEffect(() => {
     if (!loading && user) {


### PR DESCRIPTION
## Summary
- add a public landing page with an account form and local household simulator
- store onboarding profile data locally so registration can be prefilled and Firebase-ready
- reorganize authenticated routes under /app with updated navigation for desktop and mobile

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d00a9a6378832193666043d130d00a