### PR TITLE
Remove local NETLIFY_POSTGRES_URL override

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,4 +4,3 @@
 
 [build.environment]
   NODE_VERSION = "18"
-  NETLIFY_POSTGRES_URL = "postgresql://local-memory"


### PR DESCRIPTION
## Summary
- remove the default NETLIFY_POSTGRES_URL override so deployments use the configured value

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0ef6814c083219ed3d0f8a05bb1fb