### PR TITLE
Fix overview tab highlighting

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,7 +20,8 @@ const Header = () => {
   ];
 
   const isActive = (path: string) =>
-    location.pathname === path || location.pathname.startsWith(`${path}/`);
+    location.pathname === path ||
+    (path !== "/app" && location.pathname.startsWith(`${path}/`));
 
   return (
     <header className="bg-card border-b border-border">

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -20,7 +20,8 @@ const MobileNav = () => {
   ];
 
   const isActive = (path: string) =>
-    location.pathname === path || location.pathname.startsWith(`${path}/`);
+    location.pathname === path ||
+    (path !== "/app" && location.pathname.startsWith(`${path}/`));
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 flex justify-around border-t border-border bg-card py-2 sm:hidden">


### PR DESCRIPTION
## Summary
- refine active route detection so the overview tab is only highlighted on its own page
- mirror the active-state fix in the mobile navigation menu

## Testing
- npm install *(fails: 403 Forbidden when fetching pg package)*

------
https://chatgpt.com/codex/tasks/task_e_68d129e0f20c83218b1ee61d7685d64e